### PR TITLE
Remove Python upper version constraint.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 🚀 Changelog
 ============
 
+0.3.2 (2024-02-03)
+------------------
+
+- 🔓 Relax overly strict Python version constraint in package metadata (#33)
+
 0.3.1 (2024-02-01)
 ------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "whenever"
-version = "0.3.1"
+version = "0.3.2"
 description = "Foolproof datetimes for maintainable code"
 authors = ["Arie Bovenberg <a.c.bovenberg@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ repository = "https://github.com/ariebovenberg/whenever"
 keywords = ["datetime"]
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<4.0"
+python = ">=3.8.1"
 backports-zoneinfo = {version = "^0.2.1", python = "<3.9"}
 
 [tool.poetry.group.test.dependencies]


### PR DESCRIPTION
# Description

Removes the upper Python version constraint. See #33.

# Checklist

- [x] ``tox`` runs successfully
- [x] Docs updated
- [x] Version updated in ``pyproject.toml``
- [x] Version updated in changelog
- [ ] Branch merged
- [ ] Tag created and pushed
- [ ] Published
- [ ] Github release created
