### PR TITLE
Better error messages for Ambiguous end DoesntExistInZone exceptions (#26)

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -318,13 +318,13 @@ You choose the disambiguation behavior you want with the ``disambiguate=`` argum
     >>> ZonedDateTime(2023, 1, 1, tz=ams)
 
     # Ambiguous: 1:30am occurs twice. Refuse to guess.
-    >>> ZonedDateTime(2023, 10, 29, 1, 30, tz=ams)
+    >>> ZonedDateTime(2023, 10, 29, 2, 30, tz=ams)
     Traceback (most recent call last):
       ...
-    whenever.Ambiguous
+    whenever.Ambiguous: 2023-10-29 02:30:00 is ambiguous in timezone Europe/Amsterdam
 
     # Ambiguous: explicitly choose the earlier option
-    >>> ZonedDateTime(2023, 10, 29, 1, 30, tz=ams, disambiguate="earlier")
+    >>> ZonedDateTime(2023, 10, 29, 2, 30, tz=ams, disambiguate="earlier")
 
 
 Non-existence
@@ -343,7 +343,8 @@ prevent you from creating non-existent datetimes, by raising a
     >>> ZonedDateTime(2023, 3, 26, 2, 30, tz="Europe/Amsterdam")
     Traceback (most recent call last):
       ...
-    whenever.DoesntExistInZone
+    whenever.DoesntExistInZone: 2023-03-26 02:30:00 doesn't exist in timezone
+    Europe/Amsterdam
 
 
 Converting to/from standard library ``datetime``

--- a/tests/test_zoned_datetime.py
+++ b/tests/test_zoned_datetime.py
@@ -53,9 +53,11 @@ class TestInit:
 
     def test_ambiguous(self):
         # default behavior: raise
-        with pytest.raises(Ambiguous):
+        with pytest.raises(
+            Ambiguous,
+            match="2023-10-29 02:15:30 is ambiguous in timezone Europe/Amsterdam",
+        ):
             ZonedDateTime(2023, 10, 29, 2, 15, 30, tz="Europe/Amsterdam")
-
         d1 = ZonedDateTime(
             2023,
             10,
@@ -107,9 +109,10 @@ class TestInit:
         )
 
     def test_nonexistent(self):
-        with pytest.raises(DoesntExistInZone):
-            ZonedDateTime(2023, 3, 26, 2, 15, 30, tz="Europe/Amsterdam")
-        with pytest.raises(DoesntExistInZone):
+        with pytest.raises(
+            DoesntExistInZone,
+            match="2023-03-26 02:15:30 doesn't exist in timezone Europe/Amsterdam",
+        ):
             ZonedDateTime(2023, 3, 26, 2, 15, 30, tz="Europe/Amsterdam")
 
 
@@ -373,9 +376,11 @@ class TestFromNaive:
 
     def test_ambiguous(self):
         d = NaiveDateTime(2023, 10, 29, 2, 15)
-        with pytest.raises(Ambiguous):
+        with pytest.raises(
+            Ambiguous,
+            match="2023-10-29 02:15:00 is ambiguous in timezone Europe/Amsterdam",
+        ):
             ZonedDateTime.from_naive(d, tz="Europe/Amsterdam")
-
         assert ZonedDateTime.from_naive(
             d, tz="Europe/Amsterdam", disambiguate="earlier"
         ).exact_eq(
@@ -405,7 +410,10 @@ class TestFromNaive:
 
     def test_doesnt_exist(self):
         d = NaiveDateTime(2023, 3, 26, 2, 15)
-        with pytest.raises(DoesntExistInZone):
+        with pytest.raises(
+            DoesntExistInZone,
+            match="2023-03-26 02:15:00 doesn't exist in timezone Europe/Amsterdam",
+        ):
             ZonedDateTime.from_naive(d, tz="Europe/Amsterdam")
 
 
@@ -746,7 +754,10 @@ def test_from_py():
     with pytest.raises(ValueError, match="utc"):
         ZonedDateTime.from_py(d2)
 
-    with pytest.raises(DoesntExistInZone):
+    with pytest.raises(
+        DoesntExistInZone,
+        match="2023-03-26 02:15:30 doesn't exist in timezone Europe/Amsterdam",
+    ):
         ZonedDateTime.from_py(
             py_datetime(
                 2023, 3, 26, 2, 15, 30, tzinfo=ZoneInfo("Europe/Amsterdam")
@@ -881,9 +892,11 @@ class TestReplace:
             tz="Europe/Amsterdam",
             disambiguate="earlier",
         )
-        with pytest.raises(Ambiguous):
+        with pytest.raises(
+            Ambiguous,
+            match="2023-10-29 02:15:30 is ambiguous in timezone Europe/Amsterdam",
+        ):
             d.replace(disambiguate="raise")
-
         assert d.replace(disambiguate="later").exact_eq(
             ZonedDateTime(
                 2023,
@@ -900,7 +913,10 @@ class TestReplace:
 
     def test_nonexistent(self):
         d = ZonedDateTime(2023, 3, 26, 1, 15, 30, tz="Europe/Amsterdam")
-        with pytest.raises(DoesntExistInZone):
+        with pytest.raises(
+            DoesntExistInZone,
+            match="2023-03-26 02:15:30 doesn't exist in timezone Europe/Amsterdam",
+        ):
             d.replace(hour=2)
 
 


### PR DESCRIPTION
For issue #26

# Description

Better error messages for the _Ambiguous_ and _Doesn't Exist_ errors. Examples:

- `2023-10-29 02:15:00 is ambiguous in the system timezone`
- `2023-10-29 02:15:00 is ambiguous in timezone Europe/Amsterdam`
- `2023-03-26 02:15:00 doesn't exist in the system timezone`
- `2023-03-26 02:15:00 doesn't exist in timezone Europe/Amsterdam`

Instead of checking the behavior of the methods added to the exceptions I'm checking the message in every place the error is checked in any test. It's a bit more work but this way we can be sure the errors are always generated correctly.

# Checklist

I did all the check on my local system, but have not performed any of the other steps as they seem more of a maintainer's responsibility. Let me know if you expect more.

- [x] ``tox`` runs successfully
- [x] Docs updated
- [ ] Version updated in ``pyproject.toml``
- [ ] Version updated in changelog
- [ ] Branch merged
- [ ] Tag created and pushed
- [ ] Published
- [ ] Github release created
