### PR TITLE
Consistent parse exceptions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -89,4 +89,3 @@ Exceptions
 .. autoexception:: whenever.AmbiguousTime
 .. autoexception:: whenever.SkippedTime
 .. autoexception:: whenever.InvalidOffsetForZone
-.. autoexception:: whenever.InvalidFormat

--- a/src/whenever/__init__.py
+++ b/src/whenever/__init__.py
@@ -2532,7 +2532,8 @@ class UTCDateTime(_AwareDateTime):
                     parsed = parsed.replace(tzinfo=_UTC)
                 else:
                     raise ValueError(
-                        "RFC 2822 string can't have nonzero offset to be parsed as UTC"
+                        "RFC 2822 string can't have nonzero offset "
+                        "to be parsed as UTC"
                     )
             return cls._from_py_unchecked(parsed)
         except ValueError as e:

--- a/src/whenever/__init__.py
+++ b/src/whenever/__init__.py
@@ -3003,6 +3003,8 @@ class OffsetDateTime(_AwareDateTime):
                     raise ValueError("Input has a trailing lowercase 'z'")
                 if s.endswith("-00:00"):
                     raise ValueError("Input has forbidden offset '-00:00'")
+                else:
+                    raise ValueError()
         except ValueError as e:
             raise ValueError(
                 f"Could not parse as common ISO 8601 string: {s!r}"

--- a/src/whenever/__init__.py
+++ b/src/whenever/__init__.py
@@ -999,7 +999,7 @@ class TimeDelta(_ImmutableBase):
         try:
             parsed = DateTimeDelta.from_common_iso8601(s)
             if parsed._date_part:
-                raise ValueError("Date parts are not allowed.")
+                raise ValueError("Date parts are not allowed")
             return parsed._time_part
         except ValueError as e:
             raise ValueError(

--- a/src/whenever/__init__.py
+++ b/src/whenever/__init__.py
@@ -2951,7 +2951,7 @@ class OffsetDateTime(_AwareDateTime):
             return cls._from_py_unchecked(_parse_rfc3339(s))
         except ValueError as e:
             raise ValueError(
-                f"Could not parse as RFC3339 string: {s!r}"
+                f"Could not parse as RFC 3339 string: {s!r}"
             ) from e
 
     def common_iso8601(self) -> str:
@@ -4293,12 +4293,12 @@ if sys.version_info < (3, 11):  # pragma: no cover
 
     def _parse_rfc3339(s: str) -> _datetime:
         if not (m := _match_rfc3339(s)):
-            raise ValueError(f"Could not parse as RFC3339 string: {s!r}")
+            raise ValueError(f"Could not parse as RFC 3339 string: {s!r}")
         return _fromisoformat_extra(m, s)
 
     def _parse_utc_rfc3339(s: str) -> _datetime:
         if not (m := _match_utc_rfc3339(s)):
-            raise ValueError(f"Could not parse as UTC RFC3339 string: {s!r}")
+            raise ValueError(f"Could not parse as UTC RFC 3339 string: {s!r}")
         return _fromisoformat_extra(m, s)
 
     def _fromisoformat_extra(m: re.Match[str], s: str) -> _datetime:
@@ -4338,12 +4338,12 @@ else:
 
     def _parse_utc_rfc3339(s: str) -> _datetime:
         if not _match_utc_rfc3339(s):
-            raise ValueError(f"Could not parse as UTC RFC3339 string: {s!r}")
+            raise ValueError(f"Could not parse as UTC RFC 3339 string: {s!r}")
         return _fromisoformat(s.upper())
 
     def _parse_rfc3339(s: str) -> _datetime:
         if not _match_rfc3339(s):
-            raise ValueError(f"Could not parse as RFC3339 string: {s!r}")
+            raise ValueError(f"Could not parse as RFC 3339 string: {s!r}")
         return _fromisoformat(s.upper())
 
 

--- a/src/whenever/__init__.py
+++ b/src/whenever/__init__.py
@@ -1406,14 +1406,16 @@ class DateDelta(_ImmutableBase):
         ``PT0S`` is valid, but ``P3DT1H`` is not.
 
         """
-        full_delta = DateTimeDelta.from_canonical_format(s)
-        if full_delta.time_part:
+        try:
+            full_delta = DateTimeDelta.from_canonical_format(s)
+            if full_delta.time_part:
+                raise ValueError("Time parts are not allowed")
+            return full_delta.date_part
+        except ValueError as e:
             raise ValueError(
                 "Could not parse as canonical format "
-                f"or common ISO 8601 string: {s!r}. "
-                "Time parts are not allowed."
-            )
-        return full_delta.date_part
+                f"or common ISO 8601 string: {s!r}"
+            ) from e
 
     def as_tuple(self) -> tuple[int, int, int, int]:
         """Convert to a tuple of (years, months, weeks, days)

--- a/src/whenever/__init__.py
+++ b/src/whenever/__init__.py
@@ -2996,7 +2996,9 @@ class OffsetDateTime(_AwareDateTime):
             else:
                 # Examine the string again to keep the above happy path fast
                 if s[10] != "T":
-                    raise ValueError("Input seems malformed: missing 'T' separator")
+                    raise ValueError(
+                        "Input seems malformed: missing 'T' separator"
+                    )
                 if s.endswith("z"):
                     raise ValueError("Input has a trailing lowercase 'z'")
                 if s.endswith("-00:00"):

--- a/src/whenever/__init__.py
+++ b/src/whenever/__init__.py
@@ -2714,7 +2714,6 @@ class OffsetDateTime(_AwareDateTime):
         try:
             if not _match_offset_str(s):
                 raise ValueError("Input seems malformed")
-            # Catch errors thrown by _from_py_unchecked too
             return cls._from_py_unchecked(_fromisoformat(s))
         except ValueError as e:
             raise ValueError(

--- a/src/whenever/__init__.py
+++ b/src/whenever/__init__.py
@@ -996,13 +996,16 @@ class TimeDelta(_ImmutableBase):
         Any duration with a non-zero date part is considered invalid.
         ``P0D`` is valid, but ``P1DT1H`` is not.
         """
-        parsed = DateTimeDelta.from_common_iso8601(s)
-        if parsed._date_part:
+        try:
+            parsed = DateTimeDelta.from_common_iso8601(s)
+            if parsed._date_part:
+                raise ValueError("Date parts are not allowed.")
+            return parsed._time_part
+        except ValueError as e:
             raise ValueError(
                 "Could not parse as canonical format "
                 f"or common ISO 8601 string: {s!r}"
-            )
-        return parsed._time_part
+            ) from e
 
     def py_timedelta(self) -> _timedelta:
         """Convert to a :class:`~datetime.timedelta`
@@ -1407,7 +1410,8 @@ class DateDelta(_ImmutableBase):
         if full_delta.time_part:
             raise ValueError(
                 "Could not parse as canonical format "
-                f"or common ISO 8601 string: {s!r}"
+                f"or common ISO 8601 string: {s!r}. "
+                "Time parts are not allowed."
             )
         return full_delta.date_part
 

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -67,13 +67,6 @@ class TestFromCanonicalFormat:
         ):
             Date.from_canonical_format(s)
 
-    def test_week_date_exception_context(self):
-        with pytest.raises(ValueError) as exc_info:
-            Date.from_canonical_format("2020-W12-3")
-        assert exc_info.value.__cause__ is not None
-        assert isinstance(exc_info.value.__cause__, ValueError)
-        assert "week date" in str(exc_info.value.__cause__).lower()
-
 
 def test_at():
     d = Date(2021, 1, 2)

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -67,6 +67,13 @@ class TestFromCanonicalFormat:
         ):
             Date.from_canonical_format(s)
 
+    def test_week_date_exception_context(self):
+        with pytest.raises(ValueError) as exc_info:
+            Date.from_canonical_format("2020-W12-3")
+        assert exc_info.value.__cause__ is not None
+        assert isinstance(exc_info.value.__cause__, ValueError)
+        assert "week date" in str(exc_info.value.__cause__).lower()
+
 
 def test_at():
     d = Date(2021, 1, 2)

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -61,7 +61,11 @@ class TestFromCanonicalFormat:
         ],
     )
     def test_invalid(self, s):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format "
+            "or common ISO 8601 string: " + repr(s),
+        ):
             Date.from_canonical_format(s)
 
 
@@ -388,5 +392,9 @@ def test_from_common_iso8601(s, expected):
     ],
 )
 def test_from_common_iso8601_invalid(s):
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="Could not parse as canonical format or common ISO 8601 string: "
+        + repr(s),
+    ):
         Date.from_common_iso8601(s)

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -63,8 +63,7 @@ class TestFromCanonicalFormat:
     def test_invalid(self, s):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format "
-            "or common ISO 8601 string: " + repr(s),
+            match=r"Could not parse.*canonical format.*" + repr(s),
         ):
             Date.from_canonical_format(s)
 
@@ -394,7 +393,6 @@ def test_from_common_iso8601(s, expected):
 def test_from_common_iso8601_invalid(s):
     with pytest.raises(
         ValueError,
-        match="Could not parse as canonical format or common ISO 8601 string: "
-        + repr(s),
+        match=r"Could not parse.*ISO 8601.*" + repr(s),
     ):
         Date.from_common_iso8601(s)

--- a/tests/test_date_delta.py
+++ b/tests/test_date_delta.py
@@ -187,7 +187,6 @@ class TestFromCanonicalFormat:
         assert isinstance(exc_info.value.__cause__, ValueError)
         assert "time part" in str(exc_info.value.__cause__).lower()
 
-
         with pytest.raises(
             ValueError,
             match=r"Could not parse.*canonical format.*'P1Y2M3W4DT1H2M3S'",

--- a/tests/test_date_delta.py
+++ b/tests/test_date_delta.py
@@ -167,30 +167,26 @@ class TestFromCanonicalFormat:
     def test_invalid(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format "
-            "or common ISO 8601 string: 'P'",
+            match=r"Could not parse.*canonical format.*'P'",
         ):
             DateDelta.from_canonical_format("P")
 
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format "
-            "or common ISO 8601 string: 'P'",
+            match=r"Could not parse.*ISO 8601.*'P'",
         ):
             DateDelta.from_common_iso8601("P")
 
     def test_time_component_not_allowed(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format "
-            "or common ISO 8601 string: 'P1Y2M3W4DT1H2M3S'",
+            match=r"Could not parse.*ISO 8601.*'P1Y2M3W4DT1H2M3S'",
         ):
             DateDelta.from_common_iso8601("P1Y2M3W4DT1H2M3S")
 
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format "
-            "or common ISO 8601 string: 'P1Y2M3W4DT1H2M3S'",
+            match=r"Could not parse.*canonical format.*'P1Y2M3W4DT1H2M3S'",
         ):
             DateDelta.from_canonical_format("P1Y2M3W4DT1H2M3S")
 

--- a/tests/test_date_delta.py
+++ b/tests/test_date_delta.py
@@ -181,8 +181,12 @@ class TestFromCanonicalFormat:
         with pytest.raises(
             ValueError,
             match=r"Could not parse.*ISO 8601.*'P1Y2M3W4DT1H2M3S'",
-        ):
+        ) as exc_info:
             DateDelta.from_common_iso8601("P1Y2M3W4DT1H2M3S")
+        assert exc_info.value.__cause__ is not None
+        assert isinstance(exc_info.value.__cause__, ValueError)
+        assert "time part" in str(exc_info.value.__cause__).lower()
+
 
         with pytest.raises(
             ValueError,

--- a/tests/test_date_delta.py
+++ b/tests/test_date_delta.py
@@ -165,17 +165,33 @@ class TestFromCanonicalFormat:
         assert DateDelta.from_common_iso8601(input) == expect
 
     def test_invalid(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format "
+            "or common ISO 8601 string: 'P'",
+        ):
             DateDelta.from_canonical_format("P")
 
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format "
+            "or common ISO 8601 string: 'P'",
+        ):
             DateDelta.from_common_iso8601("P")
 
     def test_time_component_not_allowed(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format "
+            "or common ISO 8601 string: 'P1Y2M3W4DT1H2M3S'",
+        ):
             DateDelta.from_common_iso8601("P1Y2M3W4DT1H2M3S")
 
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format "
+            "or common ISO 8601 string: 'P1Y2M3W4DT1H2M3S'",
+        ):
             DateDelta.from_canonical_format("P1Y2M3W4DT1H2M3S")
 
 

--- a/tests/test_date_delta.py
+++ b/tests/test_date_delta.py
@@ -7,7 +7,6 @@ import pytest
 from whenever import (
     DateDelta,
     DateTimeDelta,
-    InvalidFormat,
     TimeDelta,
     days,
     months,
@@ -166,17 +165,17 @@ class TestFromCanonicalFormat:
         assert DateDelta.from_common_iso8601(input) == expect
 
     def test_invalid(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             DateDelta.from_canonical_format("P")
 
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             DateDelta.from_common_iso8601("P")
 
     def test_time_component_not_allowed(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             DateDelta.from_common_iso8601("P1Y2M3W4DT1H2M3S")
 
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             DateDelta.from_canonical_format("P1Y2M3W4DT1H2M3S")
 
 

--- a/tests/test_date_delta.py
+++ b/tests/test_date_delta.py
@@ -181,11 +181,8 @@ class TestFromCanonicalFormat:
         with pytest.raises(
             ValueError,
             match=r"Could not parse.*ISO 8601.*'P1Y2M3W4DT1H2M3S'",
-        ) as exc_info:
+        ):
             DateDelta.from_common_iso8601("P1Y2M3W4DT1H2M3S")
-        assert exc_info.value.__cause__ is not None
-        assert isinstance(exc_info.value.__cause__, ValueError)
-        assert "time part" in str(exc_info.value.__cause__).lower()
 
         with pytest.raises(
             ValueError,

--- a/tests/test_datetime_delta.py
+++ b/tests/test_datetime_delta.py
@@ -4,7 +4,7 @@ from copy import copy, deepcopy
 
 import pytest
 
-from whenever import DateDelta, DateTimeDelta, InvalidFormat, TimeDelta
+from whenever import DateDelta, DateTimeDelta, TimeDelta
 
 from .common import AlwaysEqual, NeverEqual
 
@@ -248,17 +248,17 @@ class TestFromCanonicalFormatAndCommonISO8601:
         assert DateTimeDelta.from_common_iso8601(input) == expect
 
     def test_invalid(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             DateTimeDelta.from_canonical_format("P")
 
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             DateTimeDelta.from_common_iso8601("P")
 
     def test_too_many_microseconds(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             DateTimeDelta.from_canonical_format("PT0.0000001S")
 
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             DateTimeDelta.from_common_iso8601("PT0.0000001S")
 
 

--- a/tests/test_datetime_delta.py
+++ b/tests/test_datetime_delta.py
@@ -248,17 +248,33 @@ class TestFromCanonicalFormatAndCommonISO8601:
         assert DateTimeDelta.from_common_iso8601(input) == expect
 
     def test_invalid(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format "
+            "or common ISO 8601 string: 'P'",
+        ):
             DateTimeDelta.from_canonical_format("P")
 
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format "
+            "or common ISO 8601 string: 'P'",
+        ):
             DateTimeDelta.from_common_iso8601("P")
 
     def test_too_many_microseconds(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format "
+            "or common ISO 8601 string: 'PT0.0000001S'",
+        ):
             DateTimeDelta.from_canonical_format("PT0.0000001S")
 
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format "
+            "or common ISO 8601 string: 'PT0.0000001S'",
+        ):
             DateTimeDelta.from_common_iso8601("PT0.0000001S")
 
 

--- a/tests/test_datetime_delta.py
+++ b/tests/test_datetime_delta.py
@@ -250,30 +250,26 @@ class TestFromCanonicalFormatAndCommonISO8601:
     def test_invalid(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format "
-            "or common ISO 8601 string: 'P'",
+            match=r"Could not parse.*canonical format.*'P'",
         ):
             DateTimeDelta.from_canonical_format("P")
 
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format "
-            "or common ISO 8601 string: 'P'",
+            match=r"Could not parse.*ISO 8601.*'P'",
         ):
             DateTimeDelta.from_common_iso8601("P")
 
     def test_too_many_microseconds(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format "
-            "or common ISO 8601 string: 'PT0.0000001S'",
+            match=r"Could not parse.*canonical format.*'PT0.0000001S'",
         ):
             DateTimeDelta.from_canonical_format("PT0.0000001S")
 
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format "
-            "or common ISO 8601 string: 'PT0.0000001S'",
+            match=r"Could not parse.*ISO 8601.*'PT0.0000001S'",
         ):
             DateTimeDelta.from_common_iso8601("PT0.0000001S")
 

--- a/tests/test_local_datetime.py
+++ b/tests/test_local_datetime.py
@@ -11,7 +11,6 @@ from pytest import approx
 
 from whenever import (
     AmbiguousTime,
-    InvalidFormat,
     LocalSystemDateTime,
     NaiveDateTime,
     OffsetDateTime,
@@ -545,14 +544,14 @@ class TestFromCanonicalFormat:
 
     @local_ams_tz()
     def test_unpadded(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             LocalSystemDateTime.from_canonical_format(
                 "2020-8-15T12:8:30+02:00"
             )
 
     @local_ams_tz()
     def test_overly_precise_fraction(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             LocalSystemDateTime.from_canonical_format(
                 "2020-08-15T12:08:30.123456789123+02:00"
             )
@@ -565,28 +564,28 @@ class TestFromCanonicalFormat:
             )
 
     def test_no_offset(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             LocalSystemDateTime.from_canonical_format("2020-08-15T12:08:30")
 
     def test_no_timezone(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             LocalSystemDateTime.from_canonical_format("2020-08-15T12:08:30")
 
     def test_no_seconds(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             LocalSystemDateTime.from_canonical_format("2020-08-15T12:08+02:00")
 
     def test_empty(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             LocalSystemDateTime.from_canonical_format("")
 
     def test_garbage(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             LocalSystemDateTime.from_canonical_format("garbage")
 
     @given(text())
     def test_fuzzing(self, s: str):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             LocalSystemDateTime.from_canonical_format(s)
 
 

--- a/tests/test_local_datetime.py
+++ b/tests/test_local_datetime.py
@@ -547,8 +547,7 @@ class TestFromCanonicalFormat:
     def test_unpadded(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            + re.escape("'2020-8-15T12:8:30+02:00'"),
+            match=r"Could not parse.*canonical format.*'2020-8-15T12:8:30\+02:00'",
         ):
             LocalSystemDateTime.from_canonical_format(
                 "2020-8-15T12:8:30+02:00"
@@ -558,8 +557,8 @@ class TestFromCanonicalFormat:
     def test_overly_precise_fraction(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            + re.escape("'2020-08-15T12:08:30.123456789123+02:00'"),
+            match=r"Could not parse.*canonical format.*"
+            r"'2020-08-15T12:08:30.123456789123\+02:00'",
         ):
             LocalSystemDateTime.from_canonical_format(
                 "2020-08-15T12:08:30.123456789123+02:00"
@@ -569,8 +568,7 @@ class TestFromCanonicalFormat:
     def test_invalid_offset(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            + re.escape("'2020-08-15T12:08:30-29:00'"),
+            match=r"Could not parse.*canonical format.*'2020-08-15T12:08:30-29:00'",
         ):
             LocalSystemDateTime.from_canonical_format(
                 "2020-08-15T12:08:30-29:00"
@@ -579,37 +577,34 @@ class TestFromCanonicalFormat:
     def test_no_offset(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            + re.escape("'2020-08-15T12:08:30'"),
+            match=r"Could not parse.*canonical format.*'2020-08-15T12:08:30'",
         ):
             LocalSystemDateTime.from_canonical_format("2020-08-15T12:08:30")
 
     def test_no_timezone(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            + re.escape("'2020-08-15T12:08:30'"),
+            match=r"Could not parse.*canonical format.*'2020-08-15T12:08:30'",
         ):
             LocalSystemDateTime.from_canonical_format("2020-08-15T12:08:30")
 
     def test_no_seconds(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            + re.escape("'2020-08-15T12:08+02:00'"),
+            match=r"Could not parse.*canonical format.*'2020-08-15T12:08\+02:00'",
         ):
             LocalSystemDateTime.from_canonical_format("2020-08-15T12:08+02:00")
 
     def test_empty(self):
         with pytest.raises(
-            ValueError, match="Could not parse as canonical format string: ''"
+            ValueError, match=r"Could not parse.*canonical format.*''"
         ):
             LocalSystemDateTime.from_canonical_format("")
 
     def test_garbage(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: 'garbage'",
+            match=r"Could not parse.*canonical format.*'garbage'",
         ):
             LocalSystemDateTime.from_canonical_format("garbage")
 
@@ -617,8 +612,7 @@ class TestFromCanonicalFormat:
     def test_fuzzing(self, s: str):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            + re.escape(repr(s)),
+            match=r"Could not parse.*canonical format.*" + re.escape(repr(s)),
         ):
             LocalSystemDateTime.from_canonical_format(s)
 

--- a/tests/test_local_datetime.py
+++ b/tests/test_local_datetime.py
@@ -1,4 +1,5 @@
 import pickle
+import re
 import weakref
 from copy import copy, deepcopy
 from datetime import datetime as py_datetime, timedelta, timezone
@@ -544,48 +545,81 @@ class TestFromCanonicalFormat:
 
     @local_ams_tz()
     def test_unpadded(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            + re.escape("'2020-8-15T12:8:30+02:00'"),
+        ):
             LocalSystemDateTime.from_canonical_format(
                 "2020-8-15T12:8:30+02:00"
             )
 
     @local_ams_tz()
     def test_overly_precise_fraction(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            + re.escape("'2020-08-15T12:08:30.123456789123+02:00'"),
+        ):
             LocalSystemDateTime.from_canonical_format(
                 "2020-08-15T12:08:30.123456789123+02:00"
             )
 
     @local_ams_tz()
     def test_invalid_offset(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            + re.escape("'2020-08-15T12:08:30-29:00'"),
+        ):
             LocalSystemDateTime.from_canonical_format(
                 "2020-08-15T12:08:30-29:00"
             )
 
     def test_no_offset(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            + re.escape("'2020-08-15T12:08:30'"),
+        ):
             LocalSystemDateTime.from_canonical_format("2020-08-15T12:08:30")
 
     def test_no_timezone(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            + re.escape("'2020-08-15T12:08:30'"),
+        ):
             LocalSystemDateTime.from_canonical_format("2020-08-15T12:08:30")
 
     def test_no_seconds(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            + re.escape("'2020-08-15T12:08+02:00'"),
+        ):
             LocalSystemDateTime.from_canonical_format("2020-08-15T12:08+02:00")
 
     def test_empty(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError, match="Could not parse as canonical format string: ''"
+        ):
             LocalSystemDateTime.from_canonical_format("")
 
     def test_garbage(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: 'garbage'",
+        ):
             LocalSystemDateTime.from_canonical_format("garbage")
 
     @given(text())
     def test_fuzzing(self, s: str):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            + re.escape(repr(s)),
+        ):
             LocalSystemDateTime.from_canonical_format(s)
 
 

--- a/tests/test_naive_datetime.py
+++ b/tests/test_naive_datetime.py
@@ -193,16 +193,15 @@ class TestFromCanonicalFormat:
     def test_unpadded(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            + re.escape("'2020-8-15T12:8:30'"),
+            match=r"Could not parse.*canonical format.*'2020-8-15T12:8:30'",
         ):
             NaiveDateTime.from_canonical_format("2020-8-15T12:8:30")
 
     def test_overly_precise_fraction(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            + re.escape("'2020-08-15T12:08:30.123456789123'"),
+            match=r"Could not parse.*canonical format.*"
+            "'2020-08-15T12:08:30.123456789123'",
         ):
             NaiveDateTime.from_canonical_format(
                 "2020-08-15T12:08:30.123456789123"
@@ -211,29 +210,26 @@ class TestFromCanonicalFormat:
     def test_trailing_z(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            + re.escape("'2020-08-15T12:08:30Z'"),
+            match=r"Could not parse.*canonical format.*'2020-08-15T12:08:30Z'",
         ):
             NaiveDateTime.from_canonical_format("2020-08-15T12:08:30Z")
 
     def test_no_seconds(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            + re.escape("'2020-08-15T12:08'"),
+            match=r"Could not parse.*canonical format.*'2020-08-15T12:08'",
         ):
             NaiveDateTime.from_canonical_format("2020-08-15T12:08")
 
     def test_empty(self):
         with pytest.raises(
-            ValueError, match="Could not parse as canonical format string: ''"
+            ValueError, match=r"Could not parse.*canonical format.*''"
         ):
             NaiveDateTime.from_canonical_format("")
 
     def test_garbage(self):
         with pytest.raises(
-            ValueError,
-            match="Could not parse as canonical format string: 'garbage'",
+            ValueError, match=r"Could not parse.*canonical format.*'garbage'"
         ):
             NaiveDateTime.from_canonical_format("garbage")
 
@@ -241,8 +237,7 @@ class TestFromCanonicalFormat:
     def test_fuzzing(self, s: str):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            + re.escape(repr(s)),
+            match=r"Could not parse.*canonical format.*" + re.escape(repr(s)),
         ):
             NaiveDateTime.from_canonical_format(s)
 

--- a/tests/test_naive_datetime.py
+++ b/tests/test_naive_datetime.py
@@ -191,34 +191,59 @@ class TestFromCanonicalFormat:
         ) == NaiveDateTime(2020, 8, 15, 12, 8, 30)
 
     def test_unpadded(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            + re.escape("'2020-8-15T12:8:30'"),
+        ):
             NaiveDateTime.from_canonical_format("2020-8-15T12:8:30")
 
     def test_overly_precise_fraction(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            + re.escape("'2020-08-15T12:08:30.123456789123'"),
+        ):
             NaiveDateTime.from_canonical_format(
                 "2020-08-15T12:08:30.123456789123"
             )
 
     def test_trailing_z(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            + re.escape("'2020-08-15T12:08:30Z'"),
+        ):
             NaiveDateTime.from_canonical_format("2020-08-15T12:08:30Z")
 
     def test_no_seconds(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            + re.escape("'2020-08-15T12:08'"),
+        ):
             NaiveDateTime.from_canonical_format("2020-08-15T12:08")
 
     def test_empty(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError, match="Could not parse as canonical format string: ''"
+        ):
             NaiveDateTime.from_canonical_format("")
 
     def test_garbage(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: 'garbage'",
+        ):
             NaiveDateTime.from_canonical_format("garbage")
 
     @given(text())
     def test_fuzzing(self, s: str):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            + re.escape(repr(s)),
+        ):
             NaiveDateTime.from_canonical_format(s)
 
 

--- a/tests/test_naive_datetime.py
+++ b/tests/test_naive_datetime.py
@@ -10,7 +10,6 @@ from hypothesis.strategies import text
 from whenever import (
     AmbiguousTime,
     Date,
-    InvalidFormat,
     LocalSystemDateTime,
     NaiveDateTime,
     OffsetDateTime,
@@ -192,34 +191,34 @@ class TestFromCanonicalFormat:
         ) == NaiveDateTime(2020, 8, 15, 12, 8, 30)
 
     def test_unpadded(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             NaiveDateTime.from_canonical_format("2020-8-15T12:8:30")
 
     def test_overly_precise_fraction(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             NaiveDateTime.from_canonical_format(
                 "2020-08-15T12:08:30.123456789123"
             )
 
     def test_trailing_z(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             NaiveDateTime.from_canonical_format("2020-08-15T12:08:30Z")
 
     def test_no_seconds(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             NaiveDateTime.from_canonical_format("2020-08-15T12:08")
 
     def test_empty(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             NaiveDateTime.from_canonical_format("")
 
     def test_garbage(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             NaiveDateTime.from_canonical_format("garbage")
 
     @given(text())
     def test_fuzzing(self, s: str):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             NaiveDateTime.from_canonical_format(s)
 
 

--- a/tests/test_offset_datetime.py
+++ b/tests/test_offset_datetime.py
@@ -883,7 +883,7 @@ def test_from_common_iso8601(s, expected):
 
 
 @pytest.mark.parametrize(
-    "s, message",
+    "s, sub_message",
     [
         ("2020-08-15T23:12:09", None),  # no offset
         ("2020-08-15 23:12:09+05:00", "'T' separator"),
@@ -895,13 +895,13 @@ def test_from_common_iso8601(s, expected):
         ("2020-08-15T23:12:09z", "lowercase 'z'"),
     ],
 )
-def test_from_common_iso8601_invalid(s, message):
+def test_from_common_iso8601_invalid(s, sub_message):
     with pytest.raises(
         ValueError,
         match=r"Could not parse.*ISO 8601.*" + re.escape(repr(s)),
     ) as exc_info:
         OffsetDateTime.from_common_iso8601(s)
-    if message is not None:
+    if sub_message is not None:
         assert exc_info.value.__cause__ is not None
         assert isinstance(exc_info.value.__cause__, ValueError)
-        assert message in str(exc_info.value.__cause__)
+        assert sub_message in str(exc_info.value.__cause__)

--- a/tests/test_offset_datetime.py
+++ b/tests/test_offset_datetime.py
@@ -883,21 +883,25 @@ def test_from_common_iso8601(s, expected):
 
 
 @pytest.mark.parametrize(
-    "s",
+    "s, message",
     [
-        "2020-08-15T23:12:09",  # no offset
-        "2020-08-15 23:12:09+05:00",  # no separator
-        "2020-08-15T23:12.98+05:00",  # fractional minutes
-        "2020-08-15T23:12:09-99:00",  # invalid offset
-        "2020-08-15T23:12:09-12:00:04",  # seconds offset
-        "2020-08-15T23:12:09-00:00",  # special forbidden offset
-        "2020-08-15t23:12:09-00:00",  # non-T separator
-        "2020-08-15T23:12:09z",  # lowercase Z
+        ("2020-08-15T23:12:09", None),  # no offset
+        ("2020-08-15 23:12:09+05:00", "'T' separator"),
+        ("2020-08-15T23:12.98+05:00", None),  # fractional minutes
+        ("2020-08-15T23:12:09-99:00", None),  # invalid offset
+        ("2020-08-15T23:12:09-12:00:04", None),  # seconds offset
+        ("2020-08-15T23:12:09-00:00", "forbidden offset '-00:00'"),
+        ("2020-08-15t23:12:09-00:00", "'T' separator"),
+        ("2020-08-15T23:12:09z", "lowercase 'z'"),
     ],
 )
-def test_from_common_iso8601_invalid(s):
+def test_from_common_iso8601_invalid(s, message):
     with pytest.raises(
         ValueError,
         match=r"Could not parse.*ISO 8601.*" + re.escape(repr(s)),
-    ):
+    ) as exc_info:
         OffsetDateTime.from_common_iso8601(s)
+    if message is not None:
+        assert exc_info.value.__cause__ is not None
+        assert isinstance(exc_info.value.__cause__, ValueError)
+        assert message in str(exc_info.value.__cause__)

--- a/tests/test_offset_datetime.py
+++ b/tests/test_offset_datetime.py
@@ -883,25 +883,21 @@ def test_from_common_iso8601(s, expected):
 
 
 @pytest.mark.parametrize(
-    "s, sub_message",
+    "s",
     [
-        ("2020-08-15T23:12:09", None),  # no offset
-        ("2020-08-15 23:12:09+05:00", "'T' separator"),
-        ("2020-08-15T23:12.98+05:00", None),  # fractional minutes
-        ("2020-08-15T23:12:09-99:00", None),  # invalid offset
-        ("2020-08-15T23:12:09-12:00:04", None),  # seconds offset
-        ("2020-08-15T23:12:09-00:00", "forbidden offset '-00:00'"),
-        ("2020-08-15t23:12:09-00:00", "'T' separator"),
-        ("2020-08-15T23:12:09z", "lowercase 'z'"),
+        "2020-08-15T23:12:09",  # no offset
+        "2020-08-15 23:12:09+05:00",  # no separator
+        "2020-08-15T23:12.98+05:00",  # fractional minutes
+        "2020-08-15T23:12:09-99:00",  # invalid offset
+        "2020-08-15T23:12:09-12:00:04",  # seconds offset
+        "2020-08-15T23:12:09-00:00",  # special forbidden offset
+        "2020-08-15t23:12:09-00:00",  # non-T separator
+        "2020-08-15T23:12:09z",  # lowercase Z
     ],
 )
-def test_from_common_iso8601_invalid(s, sub_message):
+def test_from_common_iso8601_invalid(s):
     with pytest.raises(
         ValueError,
         match=r"Could not parse.*ISO 8601.*" + re.escape(repr(s)),
-    ) as exc_info:
+    ):
         OffsetDateTime.from_common_iso8601(s)
-    if sub_message is not None:
-        assert exc_info.value.__cause__ is not None
-        assert isinstance(exc_info.value.__cause__, ValueError)
-        assert sub_message in str(exc_info.value.__cause__)

--- a/tests/test_offset_datetime.py
+++ b/tests/test_offset_datetime.py
@@ -793,14 +793,14 @@ def test_from_rfc3339_invalid():
     # no timezone
     with pytest.raises(
         ValueError,
-        match=r"Could not parse.*RFC3339.*'2020-08-15T23:12:09'",
+        match=r"Could not parse.*RFC 3339.*'2020-08-15T23:12:09'",
     ):
         OffsetDateTime.from_rfc3339("2020-08-15T23:12:09")
 
     # no seconds
     with pytest.raises(
         ValueError,
-        match=r"Could not parse.*RFC3339.*'2020-08-15T23:12-02:00'",
+        match=r"Could not parse.*RFC 3339.*'2020-08-15T23:12-02:00'",
     ):
         OffsetDateTime.from_rfc3339("2020-08-15T23:12-02:00")
 

--- a/tests/test_offset_datetime.py
+++ b/tests/test_offset_datetime.py
@@ -1,4 +1,5 @@
 import pickle
+import re
 import weakref
 from datetime import datetime as py_datetime, timedelta, timezone, tzinfo
 
@@ -163,38 +164,67 @@ class TestFromCanonicalFormat:
         ).exact_eq(OffsetDateTime(2020, 8, 15, 12, 8, 30, offset=-4))
 
     def test_unpadded(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            f"'{re.escape('2020-8-15T12:8:30+05:00')}'",
+        ):
             OffsetDateTime.from_canonical_format("2020-8-15T12:8:30+05:00")
 
     def test_overly_precise_fraction(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            f"'{re.escape('2020-08-15T12:08:30.123456789123+05:00')}'",
+        ):
             OffsetDateTime.from_canonical_format(
                 "2020-08-15T12:08:30.123456789123+05:00"
             )
 
     def test_invalid_offset(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            f"'{re.escape('2020-08-15T12:08:30-99:00')}'",
+        ):
             OffsetDateTime.from_canonical_format("2020-08-15T12:08:30-99:00")
 
     def test_no_offset(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            f"'{re.escape('2020-08-15T12:08:30')}'",
+        ):
             OffsetDateTime.from_canonical_format("2020-08-15T12:08:30")
 
     def test_no_seconds(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            f"'{re.escape('2020-08-15T12:08-05:00')}'",
+        ):
             OffsetDateTime.from_canonical_format("2020-08-15T12:08-05:00")
 
     def test_empty(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError, match="Could not parse as canonical format string: ''"
+        ):
             OffsetDateTime.from_canonical_format("")
 
     def test_garbage(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: 'garbage'",
+        ):
             OffsetDateTime.from_canonical_format("garbage")
 
     @given(text())
     def test_fuzzing(self, s: str):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            + re.escape(repr(s)),
+        ):
             OffsetDateTime.from_canonical_format(s)
 
 
@@ -766,11 +796,18 @@ def test_from_rfc3339(s, expect):
 
 def test_from_rfc3339_invalid():
     # no timezone
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="Could not parse as RFC3339 string: "
+        f"'{re.escape('2020-08-15T23:12:09')}'",
+    ):
         OffsetDateTime.from_rfc3339("2020-08-15T23:12:09")
 
     # no seconds
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="Could not parse as RFC3339 string: '2020-08-15T23:12-02:00'",
+    ):
         OffsetDateTime.from_rfc3339("2020-08-15T23:12-02:00")
 
 
@@ -865,5 +902,9 @@ def test_from_common_iso8601(s, expected):
     ],
 )
 def test_from_common_iso8601_invalid(s):
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="Could not parse as common ISO 8601 string: "
+        + re.escape(repr(s)),
+    ):
         OffsetDateTime.from_common_iso8601(s)

--- a/tests/test_offset_datetime.py
+++ b/tests/test_offset_datetime.py
@@ -166,16 +166,15 @@ class TestFromCanonicalFormat:
     def test_unpadded(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            f"'{re.escape('2020-8-15T12:8:30+05:00')}'",
+            match=r"Could not parse.*canonical format.*'2020-8-15T12:8:30\+05:00'",
         ):
             OffsetDateTime.from_canonical_format("2020-8-15T12:8:30+05:00")
 
     def test_overly_precise_fraction(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            f"'{re.escape('2020-08-15T12:08:30.123456789123+05:00')}'",
+            match=r"Could not parse.*canonical format.*"
+            r"'2020-08-15T12:08:30.123456789123\+05:00'",
         ):
             OffsetDateTime.from_canonical_format(
                 "2020-08-15T12:08:30.123456789123+05:00"
@@ -184,37 +183,34 @@ class TestFromCanonicalFormat:
     def test_invalid_offset(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            f"'{re.escape('2020-08-15T12:08:30-99:00')}'",
+            match=r"Could not parse.*canonical format.*'2020-08-15T12:08:30-99:00'",
         ):
             OffsetDateTime.from_canonical_format("2020-08-15T12:08:30-99:00")
 
     def test_no_offset(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            f"'{re.escape('2020-08-15T12:08:30')}'",
+            match=r"Could not parse.*canonical format.*'2020-08-15T12:08:30'",
         ):
             OffsetDateTime.from_canonical_format("2020-08-15T12:08:30")
 
     def test_no_seconds(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            f"'{re.escape('2020-08-15T12:08-05:00')}'",
+            match=r"Could not parse.*canonical format.*'2020-08-15T12:08-05:00'",
         ):
             OffsetDateTime.from_canonical_format("2020-08-15T12:08-05:00")
 
     def test_empty(self):
         with pytest.raises(
-            ValueError, match="Could not parse as canonical format string: ''"
+            ValueError, match=r"Could not parse.*canonical format.*''"
         ):
             OffsetDateTime.from_canonical_format("")
 
     def test_garbage(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: 'garbage'",
+            match=r"Could not parse.*canonical format.*'garbage'",
         ):
             OffsetDateTime.from_canonical_format("garbage")
 
@@ -222,8 +218,7 @@ class TestFromCanonicalFormat:
     def test_fuzzing(self, s: str):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            + re.escape(repr(s)),
+            match=r"Could not parse.*canonical format.*" + re.escape(repr(s)),
         ):
             OffsetDateTime.from_canonical_format(s)
 
@@ -798,15 +793,14 @@ def test_from_rfc3339_invalid():
     # no timezone
     with pytest.raises(
         ValueError,
-        match="Could not parse as RFC3339 string: "
-        f"'{re.escape('2020-08-15T23:12:09')}'",
+        match=r"Could not parse.*RFC3339.*'2020-08-15T23:12:09'",
     ):
         OffsetDateTime.from_rfc3339("2020-08-15T23:12:09")
 
     # no seconds
     with pytest.raises(
         ValueError,
-        match="Could not parse as RFC3339 string: '2020-08-15T23:12-02:00'",
+        match=r"Could not parse.*RFC3339.*'2020-08-15T23:12-02:00'",
     ):
         OffsetDateTime.from_rfc3339("2020-08-15T23:12-02:00")
 
@@ -904,7 +898,6 @@ def test_from_common_iso8601(s, expected):
 def test_from_common_iso8601_invalid(s):
     with pytest.raises(
         ValueError,
-        match="Could not parse as common ISO 8601 string: "
-        + re.escape(repr(s)),
+        match=r"Could not parse.*ISO 8601.*" + re.escape(repr(s)),
     ):
         OffsetDateTime.from_common_iso8601(s)

--- a/tests/test_offset_datetime.py
+++ b/tests/test_offset_datetime.py
@@ -8,7 +8,6 @@ from hypothesis.strategies import text
 from pytest import approx
 
 from whenever import (
-    InvalidFormat,
     LocalSystemDateTime,
     NaiveDateTime,
     OffsetDateTime,
@@ -164,11 +163,11 @@ class TestFromCanonicalFormat:
         ).exact_eq(OffsetDateTime(2020, 8, 15, 12, 8, 30, offset=-4))
 
     def test_unpadded(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             OffsetDateTime.from_canonical_format("2020-8-15T12:8:30+05:00")
 
     def test_overly_precise_fraction(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             OffsetDateTime.from_canonical_format(
                 "2020-08-15T12:08:30.123456789123+05:00"
             )
@@ -178,24 +177,24 @@ class TestFromCanonicalFormat:
             OffsetDateTime.from_canonical_format("2020-08-15T12:08:30-99:00")
 
     def test_no_offset(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             OffsetDateTime.from_canonical_format("2020-08-15T12:08:30")
 
     def test_no_seconds(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             OffsetDateTime.from_canonical_format("2020-08-15T12:08-05:00")
 
     def test_empty(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             OffsetDateTime.from_canonical_format("")
 
     def test_garbage(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             OffsetDateTime.from_canonical_format("garbage")
 
     @given(text())
     def test_fuzzing(self, s: str):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             OffsetDateTime.from_canonical_format(s)
 
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -3,7 +3,7 @@ from datetime import time as py_time, timezone as py_timezone
 
 import pytest
 
-from whenever import Date, InvalidFormat, NaiveDateTime, Time
+from whenever import Date, NaiveDateTime, Time
 
 from .common import AlwaysEqual, AlwaysLarger, AlwaysSmaller, NeverEqual
 
@@ -83,10 +83,10 @@ class TestFromCanonicalFormat:
         ],
     )
     def test_invalid(self, input):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             Time.from_canonical_format(input)
 
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             Time.from_common_iso8601(input)
 
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -86,15 +86,14 @@ class TestFromCanonicalFormat:
     def test_invalid(self, input):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format or common ISO 8601 "
-            "string: " + re.escape(repr(input)),
+            match=r"Could not parse.*canonical format.*"
+            + re.escape(repr(input)),
         ):
             Time.from_canonical_format(input)
 
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format or common ISO 8601 "
-            "string: " + re.escape(repr(input)),
+            match=r"Could not parse.*ISO 8601.*" + re.escape(repr(input)),
         ):
             Time.from_common_iso8601(input)
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -81,6 +81,7 @@ class TestFromCanonicalFormat:
             "32:02:03",
             "22:72:03",
             "22:72:93",
+            "garbage",
         ],
     )
     def test_invalid(self, input):

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,4 +1,5 @@
 import pickle
+import re
 from datetime import time as py_time, timezone as py_timezone
 
 import pytest
@@ -83,10 +84,18 @@ class TestFromCanonicalFormat:
         ],
     )
     def test_invalid(self, input):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format or common ISO 8601 "
+            "string: " + re.escape(repr(input)),
+        ):
             Time.from_canonical_format(input)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format or common ISO 8601 "
+            "string: " + re.escape(repr(input)),
+        ):
             Time.from_common_iso8601(input)
 
 

--- a/tests/test_time_delta.py
+++ b/tests/test_time_delta.py
@@ -283,15 +283,25 @@ class TestFromCommonIso8601:
         assert TimeDelta.from_common_iso8601(s) == expected
 
     @pytest.mark.parametrize(
-        "s",
-        ["P1D", "P1Y", "T1H", "PT4M3H", "PT1.5H"],
+        "s, message",
+        [
+            ("P1D", "date part"),
+            ("P1Y", "date part"),
+            ("T1H", None),
+            ("PT4M3H", None),
+            ("PT1.5H", None),
+        ],
     )
-    def test_invalid(self, s) -> None:
+    def test_invalid(self, s, message) -> None:
         with pytest.raises(
             ValueError,
             match=r"Could not parse.*ISO 8601.*" + re.escape(repr(s)),
-        ):
+        ) as exc_info:
             TimeDelta.from_common_iso8601(s)
+        if message is not None:
+            assert exc_info.value.__cause__ is not None
+            assert isinstance(exc_info.value.__cause__, ValueError)
+            assert message in str(exc_info.value.__cause__).lower()
 
 
 class TestFromCanonicalFormat:

--- a/tests/test_time_delta.py
+++ b/tests/test_time_delta.py
@@ -283,7 +283,7 @@ class TestFromCommonIso8601:
         assert TimeDelta.from_common_iso8601(s) == expected
 
     @pytest.mark.parametrize(
-        "s, message",
+        "s, sub_message",
         [
             ("P1D", "date part"),
             ("P1Y", "date part"),
@@ -292,16 +292,16 @@ class TestFromCommonIso8601:
             ("PT1.5H", None),
         ],
     )
-    def test_invalid(self, s, message) -> None:
+    def test_invalid(self, s, sub_message) -> None:
         with pytest.raises(
             ValueError,
             match=r"Could not parse.*ISO 8601.*" + re.escape(repr(s)),
         ) as exc_info:
             TimeDelta.from_common_iso8601(s)
-        if message is not None:
+        if sub_message is not None:
             assert exc_info.value.__cause__ is not None
             assert isinstance(exc_info.value.__cause__, ValueError)
-            assert message in str(exc_info.value.__cause__).lower()
+            assert sub_message in str(exc_info.value.__cause__).lower()
 
 
 class TestFromCanonicalFormat:

--- a/tests/test_time_delta.py
+++ b/tests/test_time_delta.py
@@ -283,25 +283,15 @@ class TestFromCommonIso8601:
         assert TimeDelta.from_common_iso8601(s) == expected
 
     @pytest.mark.parametrize(
-        "s, sub_message",
-        [
-            ("P1D", "date part"),
-            ("P1Y", "date part"),
-            ("T1H", None),
-            ("PT4M3H", None),
-            ("PT1.5H", None),
-        ],
+        "s",
+        ["P1D", "P1Y", "T1H", "PT4M3H", "PT1.5H"],
     )
-    def test_invalid(self, s, sub_message) -> None:
+    def test_invalid(self, s) -> None:
         with pytest.raises(
             ValueError,
             match=r"Could not parse.*ISO 8601.*" + re.escape(repr(s)),
-        ) as exc_info:
+        ):
             TimeDelta.from_common_iso8601(s)
-        if sub_message is not None:
-            assert exc_info.value.__cause__ is not None
-            assert isinstance(exc_info.value.__cause__, ValueError)
-            assert sub_message in str(exc_info.value.__cause__).lower()
 
 
 class TestFromCanonicalFormat:

--- a/tests/test_time_delta.py
+++ b/tests/test_time_delta.py
@@ -1,4 +1,5 @@
 import pickle
+import re
 import weakref
 from copy import copy, deepcopy
 from datetime import timedelta
@@ -286,7 +287,10 @@ class TestFromCommonIso8601:
         ["P1D", "P1Y", "T1H", "PT4M3H", "PT1.5H"],
     )
     def test_invalid(self, s) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match=f"Could not parse as canonical format or common ISO 8601 string: {s!r}",
+        ):
             TimeDelta.from_common_iso8601(s)
 
 
@@ -318,7 +322,11 @@ class TestFromCanonicalFormat:
         ["00:60:00", "00:00:60"],
     )
     def test_invalid_too_large(self, s):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            + re.escape(repr(s)),
+        ):
             TimeDelta.from_canonical_format(s)
 
     @pytest.mark.parametrize(
@@ -331,7 +339,11 @@ class TestFromCanonicalFormat:
         ],
     )
     def test_invalid_seperators(self, s):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            + re.escape(repr(s)),
+        ):
             TimeDelta.from_canonical_format(s)
 
 

--- a/tests/test_time_delta.py
+++ b/tests/test_time_delta.py
@@ -289,7 +289,7 @@ class TestFromCommonIso8601:
     def test_invalid(self, s) -> None:
         with pytest.raises(
             ValueError,
-            match=f"Could not parse as canonical format or common ISO 8601 string: {s!r}",
+            match=r"Could not parse.*ISO 8601.*" + re.escape(repr(s)),
         ):
             TimeDelta.from_common_iso8601(s)
 
@@ -324,8 +324,7 @@ class TestFromCanonicalFormat:
     def test_invalid_too_large(self, s):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            + re.escape(repr(s)),
+            match=r"Could not parse.*canonical format.*" + re.escape(repr(s)),
         ):
             TimeDelta.from_canonical_format(s)
 

--- a/tests/test_time_delta.py
+++ b/tests/test_time_delta.py
@@ -8,7 +8,6 @@ from pytest import approx
 
 from whenever import (
     DateDelta,
-    InvalidFormat,
     TimeDelta,
     hours,
     microseconds,
@@ -287,7 +286,7 @@ class TestFromCommonIso8601:
         ["P1D", "P1Y", "T1H", "PT4M3H", "PT1.5H"],
     )
     def test_invalid(self, s) -> None:
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             TimeDelta.from_common_iso8601(s)
 
 
@@ -319,7 +318,7 @@ class TestFromCanonicalFormat:
         ["00:60:00", "00:00:60"],
     )
     def test_invalid_too_large(self, s):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             TimeDelta.from_canonical_format(s)
 
     @pytest.mark.parametrize(
@@ -332,7 +331,7 @@ class TestFromCanonicalFormat:
         ],
     )
     def test_invalid_seperators(self, s):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             TimeDelta.from_canonical_format(s)
 
 

--- a/tests/test_utc_datetime.py
+++ b/tests/test_utc_datetime.py
@@ -816,21 +816,21 @@ def test_from_rfc3339_invalid():
     # no timezone
     with pytest.raises(
         ValueError,
-        match=r"Could not parse.*RFC3339.*'2020-08-15T23:12:09'",
+        match=r"Could not parse.*RFC 3339.*'2020-08-15T23:12:09'",
     ):
         UTCDateTime.from_rfc3339("2020-08-15T23:12:09")
 
     # no seconds
     with pytest.raises(
         ValueError,
-        match=r"Could not parse.*RFC3339.*'2020-08-15T23:12-00:00'",
+        match=r"Could not parse.*RFC 3339.*'2020-08-15T23:12-00:00'",
     ):
         UTCDateTime.from_rfc3339("2020-08-15T23:12-00:00")
 
     # nonzero offset
     with pytest.raises(
         ValueError,
-        match=r"Could not parse.*UTC RFC3339.*'2020-08-15T23:12:09\+02:00'",
+        match=r"Could not parse.*UTC RFC 3339.*'2020-08-15T23:12:09\+02:00'",
     ):
         UTCDateTime.from_rfc3339("2020-08-15T23:12:09+02:00")
 

--- a/tests/test_utc_datetime.py
+++ b/tests/test_utc_datetime.py
@@ -761,8 +761,7 @@ def test_from_rfc2822_invalid():
     # no offset
     with pytest.raises(
         ValueError,
-        match="Cannot parse as RFC 2822 string: 'Sat, 15 Aug 2020 23:12:09'. "
-        "Input must have a UTC offset.",
+        match="Cannot parse as RFC 2822 string: 'Sat, 15 Aug 2020 23:12:09'",
     ):
         UTCDateTime.from_rfc2822("Sat, 15 Aug 2020 23:12:09")
 
@@ -770,8 +769,7 @@ def test_from_rfc2822_invalid():
     with pytest.raises(
         ValueError,
         match="Cannot parse as RFC 2822 string: "
-        + re.escape("'Sat, 15 Aug 2020 23:12:09 +0200'. ")
-        + "Input can't have nonzero offset to be parsed as UTC.",
+        + re.escape("'Sat, 15 Aug 2020 23:12:09 +0200'"),
     ):
         UTCDateTime.from_rfc2822("Sat, 15 Aug 2020 23:12:09 +0200")
 

--- a/tests/test_utc_datetime.py
+++ b/tests/test_utc_datetime.py
@@ -873,7 +873,7 @@ def test_from_common_iso8601(s, expect):
 
 
 @pytest.mark.parametrize(
-    "s,message",
+    "s, message",
     [
         ("2020-08-15T23:12:09.000450", None),  # no offset
         ("2020-08-15T23:12:09+02:00", None),  # non-UTC offset

--- a/tests/test_utc_datetime.py
+++ b/tests/test_utc_datetime.py
@@ -873,7 +873,7 @@ def test_from_common_iso8601(s, expect):
 
 
 @pytest.mark.parametrize(
-    "s, message",
+    "s, sub_message",
     [
         ("2020-08-15T23:12:09.000450", None),  # no offset
         ("2020-08-15T23:12:09+02:00", None),  # non-UTC offset
@@ -884,13 +884,13 @@ def test_from_common_iso8601(s, expect):
         ("2020-08-15T23:12:09-02:00:03", None),  # seconds in offset
     ],
 )
-def test_from_common_iso8601_invalid(s, message):
+def test_from_common_iso8601_invalid(s, sub_message):
     with pytest.raises(
         ValueError,
         match=r"Could not parse.*ISO 8601.*" + re.escape(repr(s)),
     ) as exc_info:
         UTCDateTime.from_common_iso8601(s)
-    if message is not None:
+    if sub_message is not None:
         assert exc_info.value.__cause__ is not None
         assert isinstance(exc_info.value.__cause__, ValueError)
-        assert message in str(exc_info.value.__cause__)
+        assert sub_message in str(exc_info.value.__cause__)

--- a/tests/test_utc_datetime.py
+++ b/tests/test_utc_datetime.py
@@ -200,15 +200,14 @@ class TestFromCanonicalFormat:
     def test_unpadded(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            "'2020-8-15T12:8:30Z'",
+            match=r"Could not parse.*canonical format.*'2020-8-15T12:8:30Z'",
         ):
             UTCDateTime.from_canonical_format("2020-8-15T12:8:30Z")
 
     def test_overly_precise_fraction(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
+            match=r"Could not parse.*canonical format.*"
             "'2020-08-15T12:08:30.123456789123Z'",
         ):
             UTCDateTime.from_canonical_format(
@@ -218,37 +217,34 @@ class TestFromCanonicalFormat:
     def test_invalid_lowercase_z(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            "'2020-08-15T12:08:30z'",
+            match=r"Could not parse.*canonical format.*'2020-08-15T12:08:30z'",
         ):
             UTCDateTime.from_canonical_format("2020-08-15T12:08:30z")
 
     def test_no_trailing_z(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            "'2020-08-15T12:08:30'",
+            match=r"Could not parse.*canonical format.*'2020-08-15T12:08:30'",
         ):
             UTCDateTime.from_canonical_format("2020-08-15T12:08:30")
 
     def test_no_seconds(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            "'2020-08-15T12:08Z'",
+            match=r"Could not parse.*canonical format.*'2020-08-15T12:08Z'",
         ):
             UTCDateTime.from_canonical_format("2020-08-15T12:08Z")
 
     def test_empty(self):
         with pytest.raises(
-            ValueError, match="Could not parse as canonical format string: ''"
+            ValueError, match=r"Could not parse.*canonical format.*''"
         ):
             UTCDateTime.from_canonical_format("")
 
     def test_garbage(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: 'garbage'",
+            match=r"Could not parse.*canonical format.*'garbage'",
         ):
             UTCDateTime.from_canonical_format("garbage")
 
@@ -256,8 +252,7 @@ class TestFromCanonicalFormat:
     def test_fuzzing(self, s: str):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            + re.escape(repr(s)),
+            match=r"Could not parse.*canonical format.*" + re.escape(repr(s)),
         ):
             UTCDateTime.from_canonical_format(s)
 
@@ -761,23 +756,21 @@ def test_from_rfc2822_invalid():
     # no offset
     with pytest.raises(
         ValueError,
-        match="Cannot parse as RFC 2822 string: 'Sat, 15 Aug 2020 23:12:09'",
+        match=r"Cannot parse.*RFC 2822.*'Sat, 15 Aug 2020 23:12:09'",
     ):
         UTCDateTime.from_rfc2822("Sat, 15 Aug 2020 23:12:09")
 
     # nonzero offset
     with pytest.raises(
         ValueError,
-        match="Cannot parse as RFC 2822 string: "
-        + re.escape("'Sat, 15 Aug 2020 23:12:09 +0200'"),
+        match=r"Cannot parse.*RFC 2822.*'Sat, 15 Aug 2020 23:12:09 \+0200'",
     ):
         UTCDateTime.from_rfc2822("Sat, 15 Aug 2020 23:12:09 +0200")
 
     # garbage
     with pytest.raises(
         ValueError,
-        match="Cannot parse as RFC 2822 string: "
-        + re.escape("'Blurb, 2 Bla 2020 23:12:09,0'"),
+        match=r"Cannot parse.*RFC 2822.*'Blurb, 2 Bla 2020 23:12:09,0'",
     ):
         UTCDateTime.from_rfc2822("Blurb, 2 Bla 2020 23:12:09,0")
 
@@ -823,22 +816,21 @@ def test_from_rfc3339_invalid():
     # no timezone
     with pytest.raises(
         ValueError,
-        match="Could not parse as UTC RFC3339 string: '2020-08-15T23:12:09'",
+        match=r"Could not parse.*RFC3339.*'2020-08-15T23:12:09'",
     ):
         UTCDateTime.from_rfc3339("2020-08-15T23:12:09")
 
     # no seconds
     with pytest.raises(
         ValueError,
-        match="Could not parse as UTC RFC3339 string: '2020-08-15T23:12-00:00'",
+        match=r"Could not parse.*RFC3339.*'2020-08-15T23:12-00:00'",
     ):
         UTCDateTime.from_rfc3339("2020-08-15T23:12-00:00")
 
     # nonzero offset
     with pytest.raises(
         ValueError,
-        match="Could not parse as UTC RFC3339 string: "
-        + re.escape("'2020-08-15T23:12:09+02:00'"),
+        match=r"Could not parse.*UTC RFC3339.*'2020-08-15T23:12:09\+02:00'",
     ):
         UTCDateTime.from_rfc3339("2020-08-15T23:12:09+02:00")
 
@@ -889,7 +881,6 @@ def test_from_common_iso8601(s, expect):
 def test_from_common_iso8601_invalid(s):
     with pytest.raises(
         ValueError,
-        match="Could not parse as common ISO 8601 string: "
-        + re.escape(repr(s)),
+        match=r"Could not parse.*ISO 8601.*" + re.escape(repr(s)),
     ):
         UTCDateTime.from_common_iso8601(s)

--- a/tests/test_utc_datetime.py
+++ b/tests/test_utc_datetime.py
@@ -11,7 +11,6 @@ from pytest import approx
 
 from whenever import (
     Date,
-    InvalidFormat,
     LocalSystemDateTime,
     NaiveDateTime,
     OffsetDateTime,
@@ -198,38 +197,38 @@ class TestFromCanonicalFormat:
         assert UTCDateTime.from_canonical_format(s) == expect
 
     def test_unpadded(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             UTCDateTime.from_canonical_format("2020-8-15T12:8:30Z")
 
     def test_overly_precise_fraction(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             UTCDateTime.from_canonical_format(
                 "2020-08-15T12:08:30.123456789123Z"
             )
 
     def test_invalid_lowercase_z(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             UTCDateTime.from_canonical_format("2020-08-15T12:08:30z")
 
     def test_no_trailing_z(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             UTCDateTime.from_canonical_format("2020-08-15T12:08:30")
 
     def test_no_seconds(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             UTCDateTime.from_canonical_format("2020-08-15T12:08Z")
 
     def test_empty(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             UTCDateTime.from_canonical_format("")
 
     def test_garbage(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             UTCDateTime.from_canonical_format("garbage")
 
     @given(text())
     def test_fuzzing(self, s: str):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             UTCDateTime.from_canonical_format(s)
 
 

--- a/tests/test_utc_datetime.py
+++ b/tests/test_utc_datetime.py
@@ -756,7 +756,7 @@ def test_from_rfc2822_invalid():
     # no offset
     with pytest.raises(
         ValueError,
-        match=r"Cannot parse.*RFC 2822.*'Sat, 15 Aug 2020 23:12:09'",
+        match=r"Could not parse.*RFC 2822.*'Sat, 15 Aug 2020 23:12:09'",
     ) as exc_info:
         UTCDateTime.from_rfc2822("Sat, 15 Aug 2020 23:12:09")
     assert exc_info.value.__cause__ is not None
@@ -766,7 +766,7 @@ def test_from_rfc2822_invalid():
     # nonzero offset
     with pytest.raises(
         ValueError,
-        match=r"Cannot parse.*RFC 2822.*'Sat, 15 Aug 2020 23:12:09 \+0200'",
+        match=r"Could not parse.*RFC 2822.*'Sat, 15 Aug 2020 23:12:09 \+0200'",
     ) as exc_info:
         UTCDateTime.from_rfc2822("Sat, 15 Aug 2020 23:12:09 +0200")
     assert exc_info.value.__cause__ is not None
@@ -776,7 +776,7 @@ def test_from_rfc2822_invalid():
     # garbage
     with pytest.raises(
         ValueError,
-        match=r"Cannot parse.*RFC 2822.*'Blurb, 2 Bla 2020 23:12:09,0'",
+        match=r"Could not parse.*RFC 2822.*'Blurb, 2 Bla 2020 23:12:09,0'",
     ):
         UTCDateTime.from_rfc2822("Blurb, 2 Bla 2020 23:12:09,0")
 
@@ -836,7 +836,7 @@ def test_from_rfc3339_invalid():
     # nonzero offset
     with pytest.raises(
         ValueError,
-        match=r"Could not parse.*UTC RFC 3339.*'2020-08-15T23:12:09\+02:00'",
+        match=r"Could not parse.*RFC 3339.*'2020-08-15T23:12:09\+02:00'",
     ):
         UTCDateTime.from_rfc3339("2020-08-15T23:12:09+02:00")
 
@@ -873,24 +873,20 @@ def test_from_common_iso8601(s, expect):
 
 
 @pytest.mark.parametrize(
-    "s, sub_message",
+    "s",
     [
-        ("2020-08-15T23:12:09.000450", None),  # no offset
-        ("2020-08-15T23:12:09+02:00", None),  # non-UTC offset
-        ("2020-08-15 23:12:09Z", "'T' separator"),
-        ("2020-08-15t23:12:09Z", "'T' separator"),
-        ("2020-08-15T23:12:09z", "lowercase 'z'"),
-        ("2020-08-15T23:12:09-00:00", "forbidden offset '-00:00'"),
-        ("2020-08-15T23:12:09-02:00:03", None),  # seconds in offset
+        "2020-08-15T23:12:09.000450",  # no offset
+        "2020-08-15T23:12:09+02:00",  # non-UTC offset
+        "2020-08-15 23:12:09Z",  # non-T separator
+        "2020-08-15t23:12:09Z",  # non-T separator
+        "2020-08-15T23:12:09z",  # lowercase Z
+        "2020-08-15T23:12:09-00:00",  # forbidden offset
+        "2020-08-15T23:12:09-02:00:03",  # seconds in offset
     ],
 )
-def test_from_common_iso8601_invalid(s, sub_message):
+def test_from_common_iso8601_invalid(s):
     with pytest.raises(
         ValueError,
         match=r"Could not parse.*ISO 8601.*" + re.escape(repr(s)),
-    ) as exc_info:
+    ):
         UTCDateTime.from_common_iso8601(s)
-    if sub_message is not None:
-        assert exc_info.value.__cause__ is not None
-        assert isinstance(exc_info.value.__cause__, ValueError)
-        assert sub_message in str(exc_info.value.__cause__)

--- a/tests/test_zoned_datetime.py
+++ b/tests/test_zoned_datetime.py
@@ -1,4 +1,5 @@
 import pickle
+import re
 import weakref
 from copy import copy, deepcopy
 from datetime import datetime as py_datetime, timedelta, timezone
@@ -552,13 +553,23 @@ class TestFromCanonicalFormat:
         )
 
     def test_unpadded(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            + re.escape("'2020-8-15T12:8:30+05:00[Asia/Kolkata]'"),
+        ):
             ZonedDateTime.from_canonical_format(
                 "2020-8-15T12:8:30+05:00[Asia/Kolkata]"
             )
 
     def test_overly_precise_fraction(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            + re.escape(
+                "'2020-08-15T12:08:30.123456789123+05:00[Asia/Kolkata]'"
+            ),
+        ):
             ZonedDateTime.from_canonical_format(
                 "2020-08-15T12:08:30.123456789123+05:00[Asia/Kolkata]"
             )
@@ -570,32 +581,53 @@ class TestFromCanonicalFormat:
             )
 
     def test_no_offset(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            + re.escape("'2020-08-15T12:08:30[Europe/Amsterdam]'"),
+        ):
             ZonedDateTime.from_canonical_format(
                 "2020-08-15T12:08:30[Europe/Amsterdam]"
             )
 
     def test_no_timezone(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            + re.escape("'2020-08-15T12:08:30+05:00'"),
+        ):
             ZonedDateTime.from_canonical_format("2020-08-15T12:08:30+05:00")
 
     def test_no_seconds(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            + re.escape("'2020-08-15T12:08-05:00[America/New_York]'"),
+        ):
             ZonedDateTime.from_canonical_format(
                 "2020-08-15T12:08-05:00[America/New_York]"
             )
 
     def test_empty(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError, match="Could not parse as canonical format string: ''"
+        ):
             ZonedDateTime.from_canonical_format("")
 
     def test_garbage(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: 'garbage'",
+        ):
             ZonedDateTime.from_canonical_format("garbage")
 
     @given(text())
     def test_fuzzing(self, s: str):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Could not parse as canonical format string: "
+            + re.escape(repr(s)),
+        ):
             ZonedDateTime.from_canonical_format(s)
 
 

--- a/tests/test_zoned_datetime.py
+++ b/tests/test_zoned_datetime.py
@@ -555,8 +555,8 @@ class TestFromCanonicalFormat:
     def test_unpadded(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            + re.escape("'2020-8-15T12:8:30+05:00[Asia/Kolkata]'"),
+            match=r"Could not parse.*canonical format.*"
+            r"'2020-8-15T12:8:30\+05:00\[Asia/Kolkata\]'",
         ):
             ZonedDateTime.from_canonical_format(
                 "2020-8-15T12:8:30+05:00[Asia/Kolkata]"
@@ -565,10 +565,8 @@ class TestFromCanonicalFormat:
     def test_overly_precise_fraction(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            + re.escape(
-                "'2020-08-15T12:08:30.123456789123+05:00[Asia/Kolkata]'"
-            ),
+            match=r"Could not parse.*canonical format.*"
+            r"'2020-08-15T12:08:30.123456789123\+05:00\[Asia/Kolkata\]'",
         ):
             ZonedDateTime.from_canonical_format(
                 "2020-08-15T12:08:30.123456789123+05:00[Asia/Kolkata]"
@@ -583,8 +581,8 @@ class TestFromCanonicalFormat:
     def test_no_offset(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            + re.escape("'2020-08-15T12:08:30[Europe/Amsterdam]'"),
+            match=r"Could not parse.*canonical format.*"
+            r"'2020-08-15T12:08:30\[Europe/Amsterdam\]'",
         ):
             ZonedDateTime.from_canonical_format(
                 "2020-08-15T12:08:30[Europe/Amsterdam]"
@@ -593,16 +591,16 @@ class TestFromCanonicalFormat:
     def test_no_timezone(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            + re.escape("'2020-08-15T12:08:30+05:00'"),
+            match=r"Could not parse.*canonical format.*"
+            + r"'2020-08-15T12:08:30\+05:00'",
         ):
             ZonedDateTime.from_canonical_format("2020-08-15T12:08:30+05:00")
 
     def test_no_seconds(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            + re.escape("'2020-08-15T12:08-05:00[America/New_York]'"),
+            match=r"Could not parse.*canonical format.*"
+            r"'2020-08-15T12:08-05:00\[America/New_York\]'",
         ):
             ZonedDateTime.from_canonical_format(
                 "2020-08-15T12:08-05:00[America/New_York]"
@@ -610,14 +608,14 @@ class TestFromCanonicalFormat:
 
     def test_empty(self):
         with pytest.raises(
-            ValueError, match="Could not parse as canonical format string: ''"
+            ValueError, match=r"Could not parse.*canonical format.*''"
         ):
             ZonedDateTime.from_canonical_format("")
 
     def test_garbage(self):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: 'garbage'",
+            match=r"Could not parse.*canonical format.*'garbage'",
         ):
             ZonedDateTime.from_canonical_format("garbage")
 
@@ -625,8 +623,7 @@ class TestFromCanonicalFormat:
     def test_fuzzing(self, s: str):
         with pytest.raises(
             ValueError,
-            match="Could not parse as canonical format string: "
-            + re.escape(repr(s)),
+            match=r"Could not parse.*canonical format.*" + re.escape(repr(s)),
         ):
             ZonedDateTime.from_canonical_format(s)
 

--- a/tests/test_zoned_datetime.py
+++ b/tests/test_zoned_datetime.py
@@ -12,7 +12,6 @@ from pytest import approx
 from whenever import (
     AmbiguousTime,
     Date,
-    InvalidFormat,
     InvalidOffsetForZone,
     LocalSystemDateTime,
     NaiveDateTime,
@@ -553,13 +552,13 @@ class TestFromCanonicalFormat:
         )
 
     def test_unpadded(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             ZonedDateTime.from_canonical_format(
                 "2020-8-15T12:8:30+05:00[Asia/Kolkata]"
             )
 
     def test_overly_precise_fraction(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             ZonedDateTime.from_canonical_format(
                 "2020-08-15T12:08:30.123456789123+05:00[Asia/Kolkata]"
             )
@@ -571,32 +570,32 @@ class TestFromCanonicalFormat:
             )
 
     def test_no_offset(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             ZonedDateTime.from_canonical_format(
                 "2020-08-15T12:08:30[Europe/Amsterdam]"
             )
 
     def test_no_timezone(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             ZonedDateTime.from_canonical_format("2020-08-15T12:08:30+05:00")
 
     def test_no_seconds(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             ZonedDateTime.from_canonical_format(
                 "2020-08-15T12:08-05:00[America/New_York]"
             )
 
     def test_empty(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             ZonedDateTime.from_canonical_format("")
 
     def test_garbage(self):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             ZonedDateTime.from_canonical_format("garbage")
 
     @given(text())
     def test_fuzzing(self, s: str):
-        with pytest.raises(InvalidFormat):
+        with pytest.raises(ValueError):
             ZonedDateTime.from_canonical_format(s)
 
 


### PR DESCRIPTION
# Description

Addresses issue https://github.com/ariebovenberg/whenever/issues/94.

## Summary of changes

- Removed `InvalidFormat` error type, always raise `ValueError` when parsing fails.
- Included offending string in error messages.
- When available, chained the exception that caused the parsing the fail.
- Updated tests to:
    - verify that `ValueError` is raised, 
    - ensure the error message matches expectation,
    - where appropriate (e.g. when it adds information about a specific reason) verify the type and message of the chained exception.
- Updated docs to reflect all parsing errors are now `ValueErrors`.

# Checklist

- [x] Build runs successfully
- [x] Docs updated

