### PR TITLE
Add from_py_date method to Date to compliment from_py_datetime on _DateTime

### DIFF
--- a/src/whenever/__init__.py
+++ b/src/whenever/__init__.py
@@ -204,6 +204,10 @@ class Date(_ImmutableBase):
             return NotImplemented
         return self._py_date >= other._py_date
 
+    def py_date(self) -> _date:
+        """Get the underlying :class:`~datetime.date` object"""
+        return self._py_date
+
     @classmethod
     def from_py_date(cls, d: _date, /) -> Date:
         """Create from a :class:`~datetime.date`

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -6,6 +6,7 @@ from itertools import chain, product
 
 import pytest
 
+from tests.common import AlwaysEqual, AlwaysLarger, AlwaysSmaller, NeverEqual
 from whenever import (
     FRIDAY,
     MONDAY,
@@ -20,8 +21,6 @@ from whenever import (
     Time,
     days,
 )
-
-from .common import AlwaysEqual, AlwaysLarger, AlwaysSmaller, NeverEqual
 
 
 def test_basics():
@@ -149,6 +148,11 @@ def test_comparison():
 def test_add(d, kwargs, expected):
     assert d.add(**kwargs) == expected
     assert d + DateDelta(**kwargs) == expected
+
+
+def test_py():
+    d = Date(2021, 1, 2)
+    assert d.py_date() == py_date(2021, 1, 2)
 
 
 def test_from_py_date():


### PR DESCRIPTION
# Description

Simple addition of `Date.from_py_date`, matching the API of the datetime classes.

# Checklist

- [x] Build runs successfully
- [x] Docs updated

# Release checklist (maintainers only)

- [ ] Version updated in ``pyproject.toml``
- [ ] Version updated in ``src/whenever/__init__.py``
- [ ] Version updated in changelog
- [ ] Branch merged
- [ ] Tag created and pushed
- [ ] Published
- [ ] Github release created
