### PR TITLE
Fix typo

### DIFF
--- a/pysrc/whenever/_pywhenever.py
+++ b/pysrc/whenever/_pywhenever.py
@@ -1136,7 +1136,7 @@ class TimeDelta(_ImmutableBase):
 
     Note
     ----
-    A shorter was to instantiate a timedelta is to use the helper functions
+    A shorter way to instantiate a timedelta is to use the helper functions
     :func:`~whenever.hours`, :func:`~whenever.minutes`, etc.
 
     """

--- a/src/docstrings.rs
+++ b/src/docstrings.rs
@@ -128,7 +128,7 @@ TimeDelta(01:30:00)
 
 Note
 ----
-A shorter was to instantiate a timedelta is to use the helper functions
+A shorter way to instantiate a timedelta is to use the helper functions
 :func:`~whenever.hours`, :func:`~whenever.minutes`, etc.
 
 ";


### PR DESCRIPTION
# Description

Fixes a typo in "A shorter **was** to"

# Checklist

- [ ] Build runs successfully
- [ ] Type stubs updated
- [ ] Docs updated
- [x] If docstrings were affected, check if they appear correctly in the docs as well as autocomplete

# Release checklist (maintainers only)

- [ ] Version updated in ``pyproject.toml``
- [ ] Version updated in ``src/whenever/_pywhenever.py``
- [ ] Version updated in changelog
- [ ] Branch merged
- [ ] Tag created and pushed
- [ ] Confirm published job runs successfully
- [ ] Github release created
