### PR TITLE
Add missing statement in example code

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -124,6 +124,7 @@ Find the duration between two datetimes
 >>> from whenever import ZonedDateTime
 >>> d = ZonedDateTime(2025, 1, 3, hour=15, tz="America/New_York")
 >>> d2 = ZonedDateTime(2025, 1, 5, hour=8, minute=24, tz="Europe/Paris")
+>>> d2 - d
 TimeDelta(PT35h24m)
 
 Move a date by six months


### PR DESCRIPTION
# Description

Add a missing `d2 - d` statement to the example at https://whenever.readthedocs.io/en/latest/examples.html#find-the-duration-between-two-datetimes.

# Checklist

- [ ] Build runs successfully
- [ ] Type stubs updated
- [ ] Docs updated
- [ ] If docstrings were affected, check if they appear correctly in the docs as well as autocomplete

# Release checklist (maintainers only)

- [ ] Version updated in ``pyproject.toml``
- [ ] Version updated in ``src/whenever/__init__.py``
- [ ] Version updated in changelog
- [ ] Branch merged
- [ ] Tag created and pushed
- [ ] Confirm published job runs successfully
- [ ] Github release created