### PR TITLE
fix: include all test files in source dist (#266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 🚀 Changelog
 
+## 0.8.9 (2025-09-21)
+
+- Fixed not all test files included in source distribution (#266)
+
 ## 0.8.8 (2025-07-24)
 
 - Add wheels for Python 3.14 now that its ABI is stable.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,5 +5,6 @@ graft .cargo
 graft src
 graft pysrc
 graft _custom_pybuild
+graft tests
 global-exclude __pycache__
 global-exclude *.py[co]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ maintainers = [
     {name = "Arie Bovenberg", email = "a.c.bovenberg@gmail.com"},
 ]
 readme = "README.md"
-version = "0.8.8"
+version = "0.8.9"
 license = "MIT"
 description = "Modern datetime library for Python"
 requires-python = ">=3.9"

--- a/pysrc/whenever/__init__.py
+++ b/pysrc/whenever/__init__.py
@@ -31,7 +31,7 @@ if not _EXTENSION_LOADED:  # pragma: no cover
     )
 
 
-__version__ = "0.8.8"
+__version__ = "0.8.9"
 
 reset_tzpath()  # populate the tzpath once at startup
 

--- a/requirements/typecheck.txt
+++ b/requirements/typecheck.txt
@@ -1,2 +1,3 @@
-mypy>=1,<2
+# TODO: Mypy 1.18 introduces some typecheck failures. Need to investigate and fix.
+mypy>=1,<1.18
 pytest-mypy-plugins>=3,<4


### PR DESCRIPTION
# Description

Did a manual check, and everything seems to be included now. Weird that tests directory was included in the first place—but incomplete...must be something that matches `tests/test_*.py` automatically; don't have time to investigate more at the moment.

# Checklist

- [ ] Build runs successfully
- [ ] Type stubs updated
- [ ] Docs updated
- [ ] If docstrings were affected, check if they appear correctly in the docs as well as autocomplete

# Release checklist (maintainers only)

- [x] Version updated in ``pyproject.toml``
- [x] Version updated in ``src/whenever/__init__.py``
- [x] Version updated in changelog
- [ ] Branch merged
- [ ] Tag created and pushed
- [ ] Confirm publish job runs successfully
- [ ] Github release created
