### PR TITLE
refactor: use `cast_allow_subclass` for ISO parsing methods across date classes to accept `str` subtypes

### DIFF
--- a/src/classes/date.rs
+++ b/src/classes/date.rs
@@ -402,7 +402,7 @@ fn format_iso(cls: HeapType<Date>, slf: Date, args: &[PyObj], kwargs: &mut IterK
 
 fn parse_iso(cls: HeapType<Date>, s: PyObj) -> PyReturn {
     Date::parse_iso(
-        s.cast::<PyStr>()
+        s.cast_allow_subclass::<PyStr>()
             // NOTE: this exception message also needs to make sense when
             // called through the constructor
             .ok_or_type_err("When parsing from ISO format, the argument must be str")?

--- a/src/classes/date_delta.rs
+++ b/src/classes/date_delta.rs
@@ -484,7 +484,7 @@ fn format_iso(_: PyType, slf: DateDelta) -> PyReturn {
 
 fn parse_iso(cls: HeapType<DateDelta>, arg: PyObj) -> PyReturn {
     let py_str = arg
-        .cast::<PyStr>()
+        .cast_allow_subclass::<PyStr>()
         // NOTE: this exception message also needs to make sense when
         // called through the constructor
         .ok_or_type_err("When parsing from ISO format, the argument must be str")?;

--- a/src/classes/datetime_delta.rs
+++ b/src/classes/datetime_delta.rs
@@ -451,7 +451,7 @@ fn format_iso(_: PyType, d: DateTimeDelta) -> PyReturn {
 
 fn parse_iso(cls: HeapType<DateTimeDelta>, arg: PyObj) -> PyReturn {
     let binding = arg
-        .cast::<PyStr>()
+        .cast_allow_subclass::<PyStr>()
         // NOTE: this exception message also needs to make sense when
         // called through the constructor
         .ok_or_type_err("When parsing from ISO format, the argument must be str")?;

--- a/src/classes/instant.rs
+++ b/src/classes/instant.rs
@@ -524,7 +524,7 @@ fn format_iso(
 fn parse_iso(cls: HeapType<Instant>, s_obj: PyObj) -> PyReturn {
     OffsetDateTime::parse(
         s_obj
-            .cast::<PyStr>()
+            .cast_allow_subclass::<PyStr>()
             // NOTE: this exception message also needs to make sense when
             // called through the constructor
             .ok_or_type_err("When parsing from ISO format, the argument must be str")?

--- a/src/classes/monthday.rs
+++ b/src/classes/monthday.rs
@@ -158,7 +158,7 @@ fn format_iso(cls: PyType, slf: MonthDay) -> PyReturn {
 
 fn parse_iso(cls: HeapType<MonthDay>, s: PyObj) -> PyReturn {
     MonthDay::parse(
-        s.cast::<PyStr>()
+        s.cast_allow_subclass::<PyStr>()
             // NOTE: this exception message also needs to make sense when
             // called through the constructor
             .ok_or_type_err("When parsing from ISO format, the argument must be str")?

--- a/src/classes/offset_datetime.rs
+++ b/src/classes/offset_datetime.rs
@@ -602,7 +602,7 @@ fn format_iso(
 
 fn parse_iso(cls: HeapType<OffsetDateTime>, arg: PyObj) -> PyReturn {
     OffsetDateTime::parse(
-        arg.cast::<PyStr>()
+        arg.cast_allow_subclass::<PyStr>()
             // NOTE: this exception message also needs to make sense when
             // called through the constructor
             .ok_or_type_err("When parsing from ISO format, the argument must be str")?

--- a/src/classes/plain_datetime.rs
+++ b/src/classes/plain_datetime.rs
@@ -203,7 +203,7 @@ fn format_iso(
 
 fn parse_iso(cls: HeapType<DateTime>, arg: PyObj) -> PyReturn {
     DateTime::parse(
-        arg.cast::<PyStr>()
+        arg.cast_allow_subclass::<PyStr>()
             // NOTE: this exception message also needs to make sense when
             // called through the constructor
             .ok_or_type_err("When parsing from ISO format, the argument must be str")?

--- a/src/classes/time.rs
+++ b/src/classes/time.rs
@@ -494,7 +494,7 @@ fn format_iso(cls: HeapType<Time>, slf: Time, args: &[PyObj], kwargs: &mut IterK
 
 fn parse_iso(cls: HeapType<Time>, s: PyObj) -> PyReturn {
     Time::parse_iso(
-        s.cast::<PyStr>()
+        s.cast_allow_subclass::<PyStr>()
             // NOTE: this exception message also needs to make sense when
             // called through the constructor
             .ok_or_type_err("When parsing from ISO format, the argument must be str")?

--- a/src/classes/time_delta.rs
+++ b/src/classes/time_delta.rs
@@ -767,7 +767,7 @@ fn format_iso(_: PyType, slf: TimeDelta) -> PyReturn {
 
 fn parse_iso(cls: HeapType<TimeDelta>, arg: PyObj) -> PyReturn {
     let py_str = arg
-        .cast::<PyStr>()
+        .cast_allow_subclass::<PyStr>()
         // NOTE: this exception message also needs to make sense when
         // called through the constructor
         .ok_or_type_err("When parsing from ISO format, the argument must be str")?;

--- a/src/classes/yearmonth.rs
+++ b/src/classes/yearmonth.rs
@@ -153,7 +153,7 @@ fn format_iso(cls: PyType, slf: YearMonth) -> PyReturn {
 
 fn parse_iso(cls: HeapType<YearMonth>, arg: PyObj) -> PyReturn {
     let py_str = arg
-        .cast::<PyStr>()
+        .cast_allow_subclass::<PyStr>()
         // NOTE: this exception message also needs to make sense when
         // called through the constructor
         .ok_or_type_err("When parsing from ISO format, the argument must be str")?;

--- a/src/classes/zoned_datetime.rs
+++ b/src/classes/zoned_datetime.rs
@@ -900,7 +900,7 @@ fn format_iso(
 
 fn parse_iso(cls: HeapType<ZonedDateTime>, arg: PyObj) -> PyReturn {
     let py_str = arg
-        .cast::<PyStr>()
+        .cast_allow_subclass::<PyStr>()
         // NOTE: this exception message also needs to make sense when
         // called through the constructor
         .ok_or_type_err("When parsing from ISO format, the argument must be str")?;


### PR DESCRIPTION
# Description

Alter ISO parsing methods to accept `str` subclasses. Closes #260.

# Checklist

- [x] Build runs successfully
- [ ] Type stubs updated
- [ ] Docs updated
- [ ] If docstrings were affected, check if they appear correctly in the docs as well as autocomplete

# Release checklist (maintainers only)

- [ ] Version updated in ``pyproject.toml``
- [ ] Version updated in ``src/whenever/__init__.py``
- [ ] Version updated in changelog
- [ ] Branch merged
- [ ] Tag created and pushed
- [ ] Confirm publish job runs successfully
- [ ] Github release created
