### PR TITLE
Give _FracTrim a __repr__ so format errors raise ValueError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## Unreleased
+
+**Fixed**
+
+- Rendering a trimmed-fraction (``F``) field in a format-pattern error message
+  (e.g. a duplicate or unsupported ``F`` field) raised ``AttributeError``
+  instead of the intended ``ValueError`` in the pure-Python implementation.
+
+
 ## 0.10.1 (2026-07-03)
 
 **Improved**

--- a/pysrc/whenever/_format.py
+++ b/pysrc/whenever/_format.py
@@ -617,6 +617,9 @@ class _FracTrim(_Field):
             return [_DotFrac(self.width)]
         return [_Literal(ch), self]
 
+    def __repr__(self) -> str:
+        return "F" * self.width
+
 
 class _DotFrac(_Field):
     """Decimal point + trimmed fractional seconds (``.FFF``).

--- a/tests/test_format_parse.py
+++ b/tests/test_format_parse.py
@@ -167,6 +167,52 @@ class TestCompilePattern:
             Date(2024, 1, 1).format("YYYY\x00MM")
 
 
+class TestFracTrimErrorRendering:
+    """Rendering a trimmed-fraction (``F``) field inside an error message
+    must raise the intended ``ValueError``, not crash.
+
+    ``_FracTrim`` lacked a ``__repr__``, so any error that referenced such a
+    field (duplicate-field detection, unsupported-field rejection) fell back
+    to ``_Field.__repr__``, which reads the class-only ``pattern`` annotation
+    and raised ``AttributeError: '_FracTrim' object has no attribute
+    'pattern'`` instead. The Rust extension already renders these correctly.
+    """
+
+    def test_repr_matches_letter_times_count(self):
+        from whenever._format import _FracExact, _FracTrim
+
+        assert repr(_FracTrim(1)) == "F"
+        assert repr(_FracTrim(3)) == "FFF"
+        assert repr(_FracTrim(9)) == "FFFFFFFFF"
+        # mirrors the sibling fixed-width fractional field
+        assert repr(_FracExact(3)) == "fff"
+
+    @pytest.mark.parametrize("pattern", ["fF", "Ff", "ffF", "Fff", "FFFff"])
+    def test_compile_duplicate_nanos_with_frac_trim(self, pattern):
+        with pytest.raises(ValueError, match="Duplicate.*nanos"):
+            compile_pattern(pattern)
+
+    @pytest.mark.parametrize("pattern", ["fF", "Ff", "ffF", "Fff"])
+    def test_format_duplicate_nanos_with_frac_trim(self, pattern):
+        with pytest.raises(ValueError, match="Duplicate.*nanos"):
+            Time(1, 2, 3, nanosecond=4).format(pattern)
+
+    @pytest.mark.parametrize("pattern", ["fF", "ffF", "Fff"])
+    def test_parse_duplicate_nanos_with_frac_trim(self, pattern):
+        with pytest.raises(ValueError, match="Duplicate.*nanos"):
+            Time.parse("01:02:03", format=pattern)
+
+    def test_frac_trim_unsupported_for_date_format(self):
+        with pytest.raises(ValueError, match="does not support.*F"):
+            Date(2024, 3, 15).format("F")
+        with pytest.raises(ValueError, match="does not support.*FFF"):
+            Date(2024, 3, 15).format("YYYY-MM-DD FFF")
+
+    def test_frac_trim_unsupported_for_date_parse(self):
+        with pytest.raises(ValueError, match="does not support.*F"):
+            Date.parse("2024-03-15", format="F")
+
+
 class TestDateFormat:
     def test_basic(self):
         d = Date(2024, 3, 15)


### PR DESCRIPTION
### Problem

In the pure-Python implementation, a format-pattern error that references a
trimmed-fraction (`F`) field crashes with `AttributeError` instead of the
intended `ValueError`:

```python
from whenever import Time, Date

Time(1, 2, 3, nanosecond=4).format("fF")   # duplicate nanos field
# AttributeError: '_FracTrim' object has no attribute 'pattern'
Date(2024, 3, 15).format("FFF")            # F unsupported for a date
# AttributeError: '_FracTrim' object has no attribute 'pattern'
```

`_FracTrim` inherits `_Field.__repr__`, which reads `self.pattern`. `_FracTrim`
never sets that instance attribute (`pattern` is a class-only annotation), so
rendering such a field inside an error message — duplicate-field detection or
unsupported-field rejection — raises `AttributeError` rather than the documented
`ValueError`. The Rust extension already renders these correctly, so this is a
pure-Python/Rust divergence.

### Fix

Give `_FracTrim` a `__repr__` returning its letter repeated by its width (e.g.
`"FFF"`), mirroring the sibling `_FracExact`. The error paths then render and
raise `ValueError` as intended.

### Tests

`TestFracTrimErrorRendering` covers the `__repr__` output and asserts a
`ValueError` (not `AttributeError`) for duplicate-nanos and unsupported-`F`
cases across `compile_pattern`, `format`, and `parse`.

Pure-Python suite `tests/test_format_parse.py` → 225 passed. `ruff check` clean.
