### PR TITLE
Reject invalid basic-format times with a separatorless fraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- Fixed the pure Python implementation accepting invalid basic-format times
+  with a separatorless fraction (e.g. ``20200101`` or ``20103000``). These now
+  raise ``ValueError`` like the Rust extension, instead of an ``AssertionError``
+  or silently parsing a wrong value.
+  Thanks to @gaoflow for the report and fix (#391).
+
 ## 0.10.2 (2026-07-06)
 
 - Fixed an issue in the pure Python implementation where invalid format

--- a/pysrc/whenever/_parse.py
+++ b/pysrc/whenever/_parse.py
@@ -255,6 +255,10 @@ if sys.version_info >= (3, 11):
         if s.count(":") > 2:
             raise ValueError()
         if all(map("0123456789:".__contains__, s)):
+            # Reject separator-less fractions like "20200101", which CPython
+            # reads as HHMMSSff (20:20:01.01) but our grammar forbids
+            if ":" not in s and len(s) not in (2, 4, 6):
+                raise ValueError()
             # Normalize leap seconds (60) to 59
             if (s.count(":") == 2 and s.endswith(":60")) or (
                 len(s) == 6 and s[4:] == "60"

--- a/tests/test_offset_datetime.py
+++ b/tests/test_offset_datetime.py
@@ -296,6 +296,9 @@ INVALID_ISO_STRINGS = [
     # invalid seconds (61 and above should be rejected)
     "2020-08-15T12:34:61+00:00",
     "2020-08-15T12:34:99+00:00",
+    # basic-format time is HH/HHMM/HHMMSS, not a separatorless fraction
+    "2020-08-15T12083000+05:00",
+    "2020-08-15T120830123+05:00",
 ]
 
 VALID_ISO_STRINGS = [

--- a/tests/test_plain_datetime.py
+++ b/tests/test_plain_datetime.py
@@ -378,6 +378,9 @@ class TestParseIso:
             # invalid leap second cases
             "2020-08-15T12:34:61",
             "2020-08-15T12:34:99",
+            # basic-format time is HH/HHMM/HHMMSS, not a separatorless fraction
+            "20200815T12083000",
+            "2020-08-15T120830123",
         ],
     )
     def test_invalid(self, s):

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -231,6 +231,13 @@ class TestParseIso:
             "01023",
             "011",
             "2",
+            # basic format is HH/HHMM/HHMMSS only; trailing digits that CPython
+            # reads as a separatorless fraction must be rejected
+            "20103000",
+            "20200101",
+            "2010300",
+            "123045678",
+            "1230456789",
             # other
             "garbage",
             "",

--- a/tests/test_zoned_datetime.py
+++ b/tests/test_zoned_datetime.py
@@ -2781,6 +2781,9 @@ class TestParseIso:
             # invalid leap second cases
             "2020-08-15T12:34:61+00:00[UTC]",
             "2020-08-15T12:34:99+00:00[UTC]",
+            # basic-format time is HH/HHMM/HHMMSS, not a separatorless fraction
+            "2020-08-15T12083000+02:00[Europe/Amsterdam]",
+            "20200815T120830123-0400[America/New_York]",
         ],
     )
     def test_invalid(self, s):


### PR DESCRIPTION
The pure-Python `parse_iso` accepts basic-format times that the Rust extension rejects:

```python
>>> Time.parse_iso("20200101")   # pure Python
AssertionError
>>> Time.parse_iso("20103000")   # pure Python -> Time("20:10:30")
```

Both are `ValueError: Invalid format` under the Rust extension.

Basic-format times are `HH`/`HHMM`/`HHMMSS`, and a fraction needs an explicit `.`/`,`. But on 3.11+ the pure-Python path passes all-digit strings straight to `time.fromisoformat`, which reads trailing digits after `HHMMSS` as a separatorless fraction (`time.fromisoformat("20200101")` -> `20:20:01.010000`). A non-zero phantom fraction trips the `assert not t.microsecond` invariant (or corrupts the `Time` under `-O`); a zero one parses silently.

The fix rejects all-digit time components whose length isn't 2/4/6, matching the Rust grammar. It sits in the shared `time_from_iso` funnel, so the divergence spans the whole family — I added invalid-input cases for `Time`, `PlainDateTime`, `OffsetDateTime`, `Instant`, and `ZonedDateTime`. Since the suite runs against both implementations, those cases double as a parity check.
