### PR TITLE
Align pattern timezone ID parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed the pure Python custom-format parser accepting non-ASCII letters and
+  numbers in timezone IDs, bringing it in line with the Rust extension.
 - Fixed the pure Python implementation accepting invalid basic-format times
   with a separatorless fraction (e.g. ``20200101`` or ``20103000``). These now
   raise ``ValueError`` like the Rust extension, instead of an ``AssertionError``

--- a/pysrc/whenever/_format.py
+++ b/pysrc/whenever/_format.py
@@ -824,7 +824,9 @@ class _TzId(_Field):
 
     def parse_value(self, s: str, pos: int, state: _ParseState) -> int:
         start = pos
-        while pos < len(s) and (s[pos].isalnum() or s[pos] in "/_-+."):
+        while pos < len(s) and (
+            s[pos].isascii() and (s[pos].isalnum() or s[pos] in "/_-+.")
+        ):
             pos += 1
         if pos == start:
             raise ValueError(f"Expected timezone ID at position {pos}")

--- a/tests/test_format_parse.py
+++ b/tests/test_format_parse.py
@@ -784,6 +784,22 @@ class TestZonedDateTimeParse:
                 format="YYYY-MM-DD hh:mmxxx",
             )
 
+    @pytest.mark.parametrize("char", ["Ĕ", "é", "界", "𝟙", "Ⅷ", "①"])
+    @pytest.mark.parametrize(
+        ("prefix", "suffix", "match"),
+        [
+            ("", "urope/Paris", r"Expected timezone ID at position 23"),
+            ("Europe/Par", "is", r"Expected .* at position 33"),
+            ("Europe/Paris", "", r"Expected .* at position 35"),
+        ],
+    )
+    def test_non_ascii_tz_id(self, char, prefix, suffix, match):
+        with pytest.raises(ValueError, match=match):
+            ZonedDateTime.parse(
+                f"2024-03-15 14:30+01:00[{prefix}{char}{suffix}]",
+                format="YYYY-MM-DD hh:mmxxx'['VV']'",
+            )
+
     def test_missing_date_fields(self):
         with pytest.raises(ValueError, match="year.*month.*day|date.*fields"):
             ZonedDateTime.parse(

--- a/tests/test_zoned_datetime.py
+++ b/tests/test_zoned_datetime.py
@@ -2803,10 +2803,10 @@ class TestParseIso:
         with pytest.raises(TimeZoneNotFoundError):
             ZonedDateTime.parse_iso("2020-08-15T12:08:30Z[X]")
 
-        with pytest.raises((TimeZoneNotFoundError, ValueError)):
+        with pytest.raises(ValueError, match="Invalid format"):
             ZonedDateTime.parse_iso(f"2023-10-29T02:15:30+02:00[{'X' * 9999}]")
 
-        with pytest.raises((TimeZoneNotFoundError, ValueError)):
+        with pytest.raises(ValueError, match="Invalid format"):
             ZonedDateTime.parse_iso(
                 f"2023-10-29T02:15:30+02:00[{chr(1600)}]",
             )


### PR DESCRIPTION
# Description

The pure Python custom-pattern parser scans `VV` timezone IDs with
`str.isalnum()`, so it consumes non-ASCII letters and numbers that the Rust
extension rejects. The two implementations then fail at different layers:
Python reaches timezone lookup and raises `TimeZoneNotFoundError`, while Rust
reports a format error at the non-ASCII character.

This adds the missing ASCII restriction to the Python scanner. Public
`ZonedDateTime.parse()` tests cover all Unicode letter/number category families
at the start, middle, and end of the timezone ID (18 cases), and run against
both implementations. It also tightens the two malformed timezone assertions
identified in #392 to their shared `ValueError("Invalid format...")` behavior.

Verification:

- pure Python: 4019 passed, 3 skipped, 100% coverage
- Rust extension: 4020 passed, 2 skipped
- Rust: 79 passed
- full lint, format, slotscheck, clippy, sdist/twine checks pass

Follow-up to #392, as discussed in the review thread.

# Checklist

- [x] Build runs successfully
- [x] Type stubs updated (not applicable; no public API changes)
- [x] Docs updated (the behavior fix is documented in the changelog)

# Release checklist (maintainers only)

- [ ] Version updated in ``pyproject.toml``
- [ ] Version updated in changelog
- [ ] Branch merged
- [ ] Tag created and pushed
- [ ] Confirm publish job runs successfully
- [ ] Github release created
