### PR TITLE
Clarify comparison between ceil/expand and floor/trunc

### DIFF
--- a/docs/guide/rounding.md
+++ b/docs/guide/rounding.md
@@ -42,7 +42,7 @@ This results in the following modes:
 | `half_expand` | nearest increment  | away from zero |  3.5→4, -3.5→-4 |n/a  |
 | `half_even` | nearest increment  | to even | 3.5→4, 4.5→4, | {func}`round` |
 
-For positive values, the behavior of `ceil`/`floor` and `trunc`/`expand` is the same.
+For positive values, the behavior of `ceil` is identical to `expand` and the behaviour of `floor` is identical to `trunc`.
 The difference is only visible for negative values.
 
 ## Supported units


### PR DESCRIPTION
# Description

Clarify the comparison between `ceil` and `expand` and between `floor` and `trunc`. The previous wording implied (to me) that `ceil` and `floor` behaved the same for positive deltas (which is incorrect) and similarly for `expand` and `trunc`.

# Checklist

- [ ] Build runs successfully
- [ ] Type stubs updated
- [x] Docs updated
- [ ] If docstrings were affected, check if they appear correctly in the docs as well as autocomplete

# Release checklist (maintainers only)

- [ ] Version updated in ``pyproject.toml``
- [ ] Version updated in changelog
- [ ] Branch merged
- [ ] Tag created and pushed
- [ ] Confirm publish job runs successfully
- [ ] Github release created
