### PR TITLE
Fix rounding with an odd increment expanding one step early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Add LLM-friendly Markdown documentation, including `llms.txt` and
   `llms-full.txt`.
+- **Fixed**: rounding with an odd `increment` rounded away from zero one step
+  early in the Rust extension. For example
+  `TimeDelta(nanoseconds=2).round("nanosecond", increment=5, mode="half_expand")`
+  returned 5ns instead of 0ns.
 
 ## 0.10.5 (2026-08-07)
 

--- a/pysrc/whenever/_math.py
+++ b/pysrc/whenever/_math.py
@@ -260,9 +260,17 @@ def custom_round(
         case "floor":
             do_expand = remainder * sign < 0
         case "half_ceil":
-            do_expand = remainder * 2 >= (expanded - sign or 1)
+            do_expand = (
+                remainder * 2 >= expanded
+                if sign > 0
+                else remainder * 2 > expanded
+            )
         case "half_floor":
-            do_expand = remainder * 2 >= (expanded + sign or 1)
+            do_expand = (
+                remainder * 2 > expanded
+                if sign > 0
+                else remainder * 2 >= expanded
+            )
         case "half_trunc":
             do_expand = remainder * 2 > expanded
         case "half_expand":

--- a/src/domain/scalar.rs
+++ b/src/domain/scalar.rs
@@ -818,14 +818,17 @@ impl SubSecNanos {
         let tot = self.as_u32();
         let quotient = tot / increment;
         let remainder = tot % increment;
-        let threshold = match mode {
-            round::AbsMode::HalfEven => 1.max(increment / 2 + quotient.is_multiple_of(2) as u32),
-            round::AbsMode::Expand => 1,
-            round::AbsMode::Trunc => increment + 1,
-            round::AbsMode::HalfTrunc => increment / 2 + 1,
-            round::AbsMode::HalfExpand => 1.max(increment / 2),
+        // Compare against the half without dividing, so an odd increment isn't truncated.
+        let round_up = match mode {
+            round::AbsMode::Trunc => false,
+            round::AbsMode::Expand => remainder > 0,
+            round::AbsMode::HalfTrunc => remainder > increment - remainder,
+            round::AbsMode::HalfExpand => remainder >= increment - remainder,
+            round::AbsMode::HalfEven => {
+                remainder > increment - remainder
+                    || (remainder == increment - remainder && !quotient.is_multiple_of(2))
+            }
         };
-        let round_up = remainder >= threshold;
         let rounded = (quotient + round_up as u32) * increment;
         (
             DeltaSeconds::new_unchecked((rounded / 1_000_000_000).into()),

--- a/src/domain/time_delta.rs
+++ b/src/domain/time_delta.rs
@@ -127,16 +127,19 @@ impl TimeDelta {
         let total_ns = self.total_nanos();
         let quotient = total_ns.div_euclid(increment);
         let remainder = total_ns.rem_euclid(increment);
-        let threshold = match abs_mode {
+        // Compare against the half without dividing, so an odd increment isn't truncated.
+        let round_up = match abs_mode {
+            round::AbsMode::Trunc => false,
+            round::AbsMode::Expand => remainder > 0,
+            round::AbsMode::HalfTrunc => remainder > increment - remainder,
+            round::AbsMode::HalfExpand => remainder >= increment - remainder,
             round::AbsMode::HalfEven => {
-                1i128.max(increment / 2 + quotient.unsigned_abs().is_multiple_of(2) as i128)
+                remainder > increment - remainder
+                    || (remainder == increment - remainder
+                        && !quotient.unsigned_abs().is_multiple_of(2))
             }
-            round::AbsMode::Expand => 1,
-            round::AbsMode::Trunc => increment + 1,
-            round::AbsMode::HalfTrunc => increment / 2 + 1,
-            round::AbsMode::HalfExpand => 1i128.max(increment / 2),
         };
-        let result_ns = (quotient + i128::from(remainder >= threshold)) * increment;
+        let result_ns = (quotient + i128::from(round_up)) * increment;
         Some(Self {
             secs: DeltaSeconds::new(result_ns.div_euclid(NS_PER_SEC as i128) as i64)?,
             subsec: SubSecNanos::new_unchecked(result_ns.rem_euclid(NS_PER_SEC as i128) as i32),

--- a/tests/test_time_delta.py
+++ b/tests/test_time_delta.py
@@ -1279,6 +1279,37 @@ class TestRound:
             ),
             # irregular increments are fine for deltas (in contrast to datetimes)
             (
+                # an odd increment: 2ns is nearer 0 than 5, so no half-mode expands
+                TimeDelta(nanoseconds=2),
+                5,
+                "nanosecond",
+                TimeDelta.ZERO,
+                TimeDelta(nanoseconds=5),
+                TimeDelta.ZERO,
+                TimeDelta.ZERO,
+                TimeDelta.ZERO,
+            ),
+            (
+                TimeDelta(nanoseconds=7),
+                5,
+                "nanosecond",
+                TimeDelta(nanoseconds=5),
+                TimeDelta(nanoseconds=10),
+                TimeDelta(nanoseconds=5),
+                TimeDelta(nanoseconds=5),
+                TimeDelta(nanoseconds=5),
+            ),
+            (
+                -TimeDelta(nanoseconds=2),
+                5,
+                "nanosecond",
+                -TimeDelta(nanoseconds=5),
+                TimeDelta.ZERO,
+                TimeDelta.ZERO,
+                TimeDelta.ZERO,
+                TimeDelta.ZERO,
+            ),
+            (
                 TimeDelta(hours=10, minutes=30),
                 23439118,
                 "millisecond",  # FUTURE: catch non-plural units with special message?


### PR DESCRIPTION
Rounding with an **odd** `increment` rounds away from zero one step too early.

```python
from whenever import TimeDelta
TimeDelta(nanoseconds=2).round("nanosecond", increment=5, mode="half_expand")
# PT0.000000005S  -  2ns is 2 from 0 and 3 from 5, so every half-mode should give 0
```

Measured against the pure-Python reference on the released 0.10.5 wheel, where the two disagree:

```
case                     pyref            rust             true nearest
2ns  inc=5 half_expand   PT0S             PT0.000000005S   0    MISMATCH
7ns  inc=5 half_even     PT0.000000005S   PT0.00000001S    5    MISMATCH
4ns  inc=9 half_expand   PT0S             PT0.000000009S   0    MISMATCH
13ns inc=9 half_even     PT0.000000009S   PT0.000000018S   9    MISMATCH
2ns  inc=4 half_expand   PT0.000000004S   PT0.000000004S   tie  (even increment, control)
```

It reaches `Instant.round`, `Time.round` and `PlainDateTime.round` too:

```
Instant …T00:00:00.000000002Z .round('nanosecond', increment=5, mode='half_expand')
  rust  -> 2020-01-01T00:00:00.000000005Z
  pyref -> 2020-01-01T00:00:00Z
```

### Cause

Both Rust threshold tables derive the half point by dividing:

```rust
round::AbsMode::HalfExpand => 1.max(increment / 2),
round::AbsMode::HalfEven   => 1.max(increment / 2 + quotient.is_multiple_of(2) as u32),
```

For an odd increment `E`, `E / 2` truncates to `(E-1)/2`, so a remainder of `(E-1)/2` — strictly
below half — still satisfies `remainder >= threshold`. `HalfExpand` is wrong for every odd `E`;
`HalfEven` is wrong for odd `E` whenever `quotient` is odd, because the `+1` term vanishes.

Two sites, because the increment may or may not divide 1e9: `src/domain/scalar.rs:821` takes
`increment=5` (5 divides 1e9), `src/domain/time_delta.rs:130` takes `increment=9`.

`custom_round` in `_math.py` already avoids this for the other modes by comparing the **doubled**
remainder rather than halving the increment, so the fix is to do the same in Rust. I wrote it as
`remainder > increment - remainder` so it cannot overflow the `i128` path.

### One more site, same defect

`_math.py`'s `half_ceil`/`half_floor` do the same thing through a `±1` adjustment:

```python
do_expand = remainder * 2 >= (expanded - sign or 1)
```

`expanded - 1` is exact only when `expanded` is even. For `TimeDelta(nanoseconds=2)` with
`increment=5`, `half_ceil` gives 5ns where the nearest multiple is 0 — and because **both**
implementations were wrong here, the Rust/Python differential stayed silent on it. Fixing only the
Rust side would leave `half_ceil` as the one remaining inconsistency, so I changed it too:

```python
case "half_ceil":
    do_expand = remainder * 2 >= expanded if sign > 0 else remainder * 2 > expanded
case "half_floor":
    do_expand = remainder * 2 > expanded if sign > 0 else remainder * 2 >= expanded
```

Happy to split that into its own PR if you would rather keep them separate — it is a different file
but the same defect.

### Why the tests missed it

`tests/test_time_delta.py:1280` says *"irregular increments are fine for deltas (in contrast to
datetimes)"* and then supplies exactly one irregular case: increment `23439118` on `millisecond`.
That is an even number on a unit with an even ns-per-unit, so `increment_ns` is even and the
truncating `/2` is exact. **The table contains no odd `increment_ns` anywhere** — and an odd
`increment_ns` is only reachable through the `nanosecond` unit, which the table skips for irregular
increments. `increment_to_ns_for_delta` accepts any positive integer, so odd increments are
supported public API.

### Tests

Three rows added to that same table: `2ns`/`inc=5`, `7ns`/`inc=5`, and `-2ns`/`inc=5`. Reverting the
three source files and keeping them:

```
### RED - rust ext
E  assert TimeDelta("PT0.000000005s") == TimeDelta("PT0s")
E  assert TimeDelta("PT0.00000001s")  == TimeDelta("PT0.000000005s")
FAILED tests/test_time_delta.py::TestRound::test_valid[t13-5-nanosecond-…]
FAILED tests/test_time_delta.py::TestRound::test_valid[t14-5-nanosecond-…]

### RED - pure python (WHENEVER_NO_BUILD_RUST_EXT=1)
FAILED …[t13-5-nanosecond-…]
FAILED …[t14-5-nanosecond-…]
2 failed, 34 passed
```

and restored: `36 passed`.

Green on everything: `make test-py` → `4178 passed, 2 skipped`; the pure-Python path →
`288 passed`; `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.
`CHANGELOG.md` updated under Unreleased.

Note on the red/green: `make init` does not rebuild the extension on its own, so each direction
above was measured after `rm -f pysrc/whenever/*.so` and
`uv sync --reinstall-package whenever`. My first attempt at the red run reported a false green
because of exactly that.

**Observable change:** `.round(..., increment=<odd>, ...)` in the half modes now returns the nearest
multiple where it previously expanded early, and `half_ceil`/`half_floor` change for odd increments
in both implementations. No existing test changes result.

`CONTRIBUTING.md` asks that non-trivial changes start as an issue — happy to move this there if you
prefer; I led with the repro table so the call is easy either way.

---

Disclosure: found and prepared with AI assistance (Claude). Every figure above is from a run on this
branch, and the root cause is one I traced and verified by hand, not a tool's summary.
